### PR TITLE
Fix wrong interface usage

### DIFF
--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -184,7 +184,8 @@ class Fieldset extends Element implements FieldsetInterface
             $order = $flags['priority'];
         }
 
-        $this->iterator->insert($name, $elementOrFieldset, $order);
+        // fix bug with Zend\Stdlib\PriorityQueue::insert 
+        $this->iterator->insert($elementOrFieldset, $order);
 
         if ($elementOrFieldset instanceof FieldsetInterface) {
             $this->fieldsets[$name] = $elementOrFieldset;


### PR DESCRIPTION
Original implementation of Zend\Stdlib\PriorityQueue::insert  applies only 2 arguments
```
    /**
     * Insert an item into the queue
     *
     * Priority defaults to 1 (low priority) if none provided.
     *
     * @param  mixed $data
     * @param  int $priority
     * @return PriorityQueue
     */
    public function insert($data, $priority = 1)
```