### PR TITLE
fixed failing test

### DIFF
--- a/test/View/Helper/FormRowTest.php
+++ b/test/View/Helper/FormRowTest.php
@@ -121,7 +121,7 @@ class FormRowTest extends TestCase
         $element = new Element\Hidden('foo');
         $element->setLabel('My label');
         $markup = $this->helper->render($element);
-        $this->assertEquals('<input type="hidden" name="foo" value=""/>', $markup);
+        $this->assertRegexp('/<input type="hidden" name="foo" value=""[^\/>]*\/?>/', $markup);
     }
 
     public function testCanHandleMultiCheckboxesCorrectly()


### PR DESCRIPTION
When running tests locally there was one failing test:
```
There was 1 failure:

1) ZendTest\Form\View\Helper\FormRowTest::testIgnoreLabelForHidden
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'<input type="hidden" name="foo" value=""/>'
+'<input type="hidden" name="foo" value="">'

/vagrant/projects/zend-form/test/View/Helper/FormRowTest.php:124
```