### PR TITLE
Update stdlib version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.5",
         "zendframework/zend-inputfilter": "~2.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "zendframework/zend-stdlib": ">=2.5.0,<2.7.0"
     },
     "require-dev": {
         "doctrine/annotations": "~1.0",


### PR DESCRIPTION
To < 2.7.0, to ensure only hydrators implementing the stdlib hydrator interfaces will work.