### PR TITLE
Stop FormRow from translating the label twice

### DIFF
--- a/src/View/Helper/FormRow.php
+++ b/src/View/Helper/FormRow.php
@@ -196,14 +196,12 @@ class FormRow extends AbstractHelper
                 // If element has label option `always_wrap` it will be nested in any case.
                 if ($element->hasAttribute('id')
                     && ($element instanceof LabelAwareInterface && !$element->getLabelOption('always_wrap'))
-                ) {
-                    $labelOpen = '';
-                    $labelClose = '';
-                    $label = $labelHelper($element);
+                ) { 
+                    $labelOpen = $labelHelper->openTag($element);
                 } else {
                     $labelOpen  = $labelHelper->openTag($labelAttributes);
-                    $labelClose = $labelHelper->closeTag();
                 }
+                $labelClose = $labelHelper->closeTag();
 
                 if ($label !== '' && (!$element->hasAttribute('id'))
                     || ($element instanceof LabelAwareInterface && $element->getLabelOption('always_wrap'))

--- a/src/View/Helper/FormRow.php
+++ b/src/View/Helper/FormRow.php
@@ -197,11 +197,14 @@ class FormRow extends AbstractHelper
                 if ($element->hasAttribute('id')
                     && ($element instanceof LabelAwareInterface && !$element->getLabelOption('always_wrap'))
                 ) { 
-                    $labelOpen = $labelHelper->openTag($element);
+                    $labelOpen = '';
+                    $labelClose = '';
+                    $label = $labelHelper->openTag($element) . $label . $labelHelper->closeTag();
                 } else {
                     $labelOpen  = $labelHelper->openTag($labelAttributes);
+                    $labelClose = $labelHelper->closeTag();
                 }
-                $labelClose = $labelHelper->closeTag();
+                
 
                 if ($label !== '' && (!$element->hasAttribute('id'))
                     || ($element instanceof LabelAwareInterface && $element->getLabelOption('always_wrap'))

--- a/src/View/Helper/FormRow.php
+++ b/src/View/Helper/FormRow.php
@@ -196,7 +196,7 @@ class FormRow extends AbstractHelper
                 // If element has label option `always_wrap` it will be nested in any case.
                 if ($element->hasAttribute('id')
                     && ($element instanceof LabelAwareInterface && !$element->getLabelOption('always_wrap'))
-                ) { 
+                ) {
                     $labelOpen = '';
                     $labelClose = '';
                     $label = $labelHelper->openTag($element) . $label . $labelHelper->closeTag();
@@ -204,7 +204,6 @@ class FormRow extends AbstractHelper
                     $labelOpen  = $labelHelper->openTag($labelAttributes);
                     $labelClose = $labelHelper->closeTag();
                 }
-                
 
                 if ($label !== '' && (!$element->hasAttribute('id'))
                     || ($element instanceof LabelAwareInterface && $element->getLabelOption('always_wrap'))

--- a/test/View/Helper/FormRowTest.php
+++ b/test/View/Helper/FormRowTest.php
@@ -248,6 +248,45 @@ class FormRowTest extends TestCase
         $this->assertFalse($this->helper->isTranslatorEnabled());
     }
 
+    public function testLabelWillBeTranslatedOnceWithoutId()
+    {
+        $element = new Element('foo');
+        $element->setLabel('The value for foo:');
+
+        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+        $mockTranslator->expects($this->exactly(1))
+            ->method('translate')
+            ->will($this->returnValue('translated content'));
+
+        $this->helper->setTranslator($mockTranslator);
+        $this->assertTrue($this->helper->hasTranslator());
+
+        $markup = $this->helper->__invoke($element);
+        $this->assertContains('>translated content<', $markup);
+        $this->assertContains('<label', $markup);
+        $this->assertContains('</label>', $markup);
+    }
+
+    public function testLabelWillBeTranslatedOnceWithId()
+    {
+        $element = new Element('foo');
+        $element->setLabel('The value for foo:');
+        $element->setAttribute('id', 'foo');
+
+        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+        $mockTranslator->expects($this->exactly(1))
+            ->method('translate')
+            ->will($this->returnValue('translated content'));
+
+        $this->helper->setTranslator($mockTranslator);
+        $this->assertTrue($this->helper->hasTranslator());
+
+        $markup = $this->helper->__invoke($element);
+        $this->assertContains('>translated content<', $markup);
+        $this->assertContains('<label', $markup);
+        $this->assertContains('</label>', $markup);
+    }
+    
     public function testSetLabelPositionInputNullRaisesException()
     {
         $this->setExpectedException('Zend\Form\Exception\InvalidArgumentException');

--- a/test/View/Helper/FormRowTest.php
+++ b/test/View/Helper/FormRowTest.php
@@ -286,7 +286,7 @@ class FormRowTest extends TestCase
         $this->assertContains('<label', $markup);
         $this->assertContains('</label>', $markup);
     }
-    
+
     public function testSetLabelPositionInputNullRaisesException()
     {
         $this->setExpectedException('Zend\Form\Exception\InvalidArgumentException');


### PR DESCRIPTION
Prevents the label from being translated and processed multiple times. When $labelHelper is invoked with only one argument, it will translate and process the label, and not add anything extra. There is no need for this extra work in FormRow, which has already done this translation. This small change also allows for a more uniform code path when the element has an id and when it does not.