### PR TITLE
Inject input filter factory when creating new input filter

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -687,6 +687,7 @@ class Form extends Fieldset implements FormInterface
 
         if (!isset($this->filter)) {
             $this->filter = new InputFilter();
+            $this->filter->setFactory($this->getFormFactory()->getInputFilterFactory());
         }
 
         if (!$this->hasAddedInputFilterDefaults

--- a/src/Form.php
+++ b/src/Form.php
@@ -679,6 +679,7 @@ class Form extends Fieldset implements FormInterface
                 $name = $this->baseFieldset->getName();
                 if (!$this->filter instanceof InputFilterInterface || !$this->filter->has($name)) {
                     $filter = new InputFilter();
+                    $filter->setFactory($this->getFormFactory()->getInputFilterFactory());
                     $filter->add($this->object->getInputFilter(), $name);
                     $this->filter = $filter;
                 }

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -2139,8 +2139,20 @@ class FormTest extends TestCase
     /**
      * Test for https://github.com/zendframework/zend-form/pull/24#issue-119023527
      */
-    public function testGetInputFilterInjectsFormInputFilterFactoryInstance()
+    public function testGetInputFilterInjectsFormInputFilterFactoryInstanceObjectIsNull()
     {
+        $inputFilterFactory = $this->form->getFormFactory()->getInputFilterFactory();
+        $inputFilter = $this->form->getInputFilter();
+        $this->assertSame($inputFilterFactory, $inputFilter->getFactory());
+    }
+
+    /**
+     * Test for https://github.com/zendframework/zend-form/pull/24#issuecomment-159905491
+     */
+    public function testGetInputFilterInjectsFormInputFilterFactoryInstanceWhenObjectIsInputFilterAware()
+    {
+        $this->form->setBaseFieldset(new Fieldset());
+        $this->form->bind(new TestAsset\Entity\Cat());
         $inputFilterFactory = $this->form->getFormFactory()->getInputFilterFactory();
         $inputFilter = $this->form->getInputFilter();
         $this->assertSame($inputFilterFactory, $inputFilter->getFactory());

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -2135,4 +2135,14 @@ class FormTest extends TestCase
 
         $this->assertEquals($data, $this->form->getData());
     }
+    
+    /**
+     * Test for https://github.com/zendframework/zend-form/pull/24#issue-119023527
+     */
+    public function testGetInputFilterInjectsFormInputFilterFactoryInstance()
+    {
+        $inputFilterFactory = $this->form->getFormFactory()->getInputFilterFactory();
+        $inputFilter = $this->form->getInputFilter();
+        $this->assertSame($inputFilterFactory, $inputFilter->getFactory());
+    }
 }

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -2152,6 +2152,7 @@ class FormTest extends TestCase
     public function testGetInputFilterInjectsFormInputFilterFactoryInstanceWhenObjectIsInputFilterAware()
     {
         $this->form->setBaseFieldset(new Fieldset());
+        $this->form->setHydrator(new Hydrator\ClassMethods());
         $this->form->bind(new TestAsset\Entity\Cat());
         $inputFilterFactory = $this->form->getFormFactory()->getInputFilterFactory();
         $inputFilter = $this->form->getInputFilter();

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -2135,7 +2135,7 @@ class FormTest extends TestCase
 
         $this->assertEquals($data, $this->form->getData());
     }
-    
+
     /**
      * Test for https://github.com/zendframework/zend-form/pull/24#issue-119023527
      */

--- a/test/TestAsset/Entity/Cat.php
+++ b/test/TestAsset/Entity/Cat.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset\Entity;
+
+use Zend\InputFilter\InputFilter;
+use Zend\InputFilter\InputFilterInterface;
+use Zend\InputFilter\InputFilterAwareInterface;
+
+class Cat implements InputFilterAwareInterface
+{
+    /**
+     * @var string
+     */
+    protected $name = null;
+
+    /**
+     * @var InputFilterInterface
+     */
+    protected $inputFilter = null;
+
+    /**
+     * @param string $name
+     * @return Cat
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set input filter
+     *
+     * @param  InputFilterInterface $inputFilter
+     * @return Cat
+     */
+    public function setInputFilter(InputFilterInterface $inputFilter)
+    {
+        $this->inputFilter = $inputFilter;
+        return $this;
+    }
+
+    /**
+     * Retrieve input filter
+     *
+     * @return InputFilterInterface
+     */
+    public function getInputFilter()
+    {
+        if (null === $this->inputFilter) {
+            $this->inputFilter = new InputFilter();
+        }
+        return $this->inputFilter;
+    }
+}


### PR DESCRIPTION
Custom validators and filters are not available in forms pulled from the `FormElementManager`. I already discussed this issue [here](https://github.com/zendframework/zend-inputfilter/issues/79).

When the object bound to the form does not implement `InputFilterAwareInterface`, the form creates its `InputFilter` instance itself when `getInputFilter` gets called:

```php
$this->filter = new InputFilter();
```

In this case, the `Zend\InputFilter\Factory` dependency of this newly created input filter instance does not get satisfied which results in creating a different factory instance with separate `ServiceManagers` lazily.

The form has a pointer to a `Zend\InputFilter\Factory` instance with properly injected `ServiceManagers`. Adding following line right after the statement shown above makes custom filters and validators available inside the form as expected:

```php
$this->filter->setFactory($this->getFormFactory()->getInputFilterFactory());
```

Both `getFormFactory` and `getInputFilterFactory` create instances lazily if they have not been injected. This statement should never fail.