### PR TITLE
Issue 37 add aria tags

### DIFF
--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -355,6 +355,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
             if (!isset($this->validGlobalAttributes[$attribute])
                 && !isset($this->validTagAttributes[$attribute])
                 && 'data-' != substr($attribute, 0, 5)
+                && 'aria-' != substr($attribute, 0, 5)
                 && 'x-' != substr($attribute, 0, 2)
             ) {
                 // Invalid attribute for the current tag

--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -130,8 +130,6 @@ abstract class AbstractHelper extends BaseAbstractHelper
         'onvolumechange'     => true,
         'onwaiting'          => true,
         'role'               => true,
-        'aria-labelledby'    => true,
-        'aria-describedby'   => true,
         'spellcheck'         => true,
         'style'              => true,
         'tabindex'           => true,

--- a/test/ElementTest.php
+++ b/test/ElementTest.php
@@ -339,7 +339,7 @@ class ElementTest extends TestCase
             'type'             => 'text',
             'aria-label'       => 'alb',
             'aria-describedby' => 'adb',
-	        'aria-orientation' => 'vertical'
+            'aria-orientation' => 'vertical'
         ];
         $element->setAttributes($attributes);
         $this->assertTrue($element->hasAttribute('aria-describedby'));

--- a/test/ElementTest.php
+++ b/test/ElementTest.php
@@ -331,34 +331,34 @@ class ElementTest extends TestCase
         $this->assertTrue($element->hasLabelOption('foo3'));
     }
 
-	public function testCanAddMultipleAriaAttributes()
-	{
-		$element = new Element();
-		$attributes = [
-			'type'             => 'text',
-			'aria-label'       => 'alb',
-			'aria-describedby' => 'adb',
-			'aria-orientation' => 'vertical'
-		];
-		$element->setAttributes($attributes);
-		$this->assertTrue($element->hasAttribute('aria-describedby'));
-		$this->assertTrue($element->hasAttribute('aria-label'));
-		$this->assertTrue($element->hasAttribute('aria-orientation'));
-	}
+    public function testCanAddMultipleAriaAttributes()
+    {
+        $element = new Element();
+        $attributes = [
+            'type'             => 'text',
+            'aria-label'       => 'alb',
+            'aria-describedby' => 'adb',
+            'aria-orientation' => 'vertical'
+        ];
+        $element->setAttributes($attributes);
+        $this->assertTrue($element->hasAttribute('aria-describedby'));
+        $this->assertTrue($element->hasAttribute('aria-label'));
+        $this->assertTrue($element->hasAttribute('aria-orientation'));
+    }
 
-	public function testCanRemoveMultipleAriaAttributes()
-	{
-		$element = new Element();
-		$attributes = [
-			'type'             => 'text',
-			'aria-label'       => 'alb',
-			'aria-describedby' => 'adb',
-			'aria-orientation' => 'vertical'
-		];
-		$element->setAttributes($attributes);
-		$element->removeAttributes(['aria-label', 'aria-describedby', 'aria-orientation']);
-		$this->assertFalse($element->hasAttribute('aria-describedby'));
-		$this->assertFalse($element->hasAttribute('aria-label'));
-		$this->assertFalse($element->hasAttribute('aria-orientation'));
-	}
+    public function testCanRemoveMultipleAriaAttributes()
+    {
+        $element = new Element();
+        $attributes = [
+            'type'             => 'text',
+            'aria-label'       => 'alb',
+            'aria-describedby' => 'adb',
+            'aria-orientation' => 'vertical'
+        ];
+        $element->setAttributes($attributes);
+        $element->removeAttributes(['aria-label', 'aria-describedby', 'aria-orientation']);
+        $this->assertFalse($element->hasAttribute('aria-describedby'));
+        $this->assertFalse($element->hasAttribute('aria-label'));
+        $this->assertFalse($element->hasAttribute('aria-orientation'));
+    }
 }

--- a/test/ElementTest.php
+++ b/test/ElementTest.php
@@ -332,18 +332,35 @@ class ElementTest extends TestCase
     }
 
 
-    public function testCanAddMultipleAriaAttributes()
-    {
-        $element = new Element();
-        $attributes = [
-            'type'             => 'text',
-            'aria-label'       => 'alb',
-            'aria-describedby' => 'adb',
-            'aria-orientation' => 'vertical'
-        ];
-        $element->setAttributes($attributes);
-        $this->assertTrue($element->hasAttribute('aria-describedby'));
-        $this->assertTrue($element->hasAttribute('aria-label'));
-        $this->assertTrue($element->hasAttribute('aria-orientation'));
-    }
+	public function testCanAddMultipleAriaAttributes()
+	{
+		$element = new Element();
+		$attributes = [
+			'type'             => 'text',
+			'aria-label'       => 'alb',
+			'aria-describedby' => 'adb',
+			'aria-orientation' => 'vertical'
+		];
+		$element->setAttributes($attributes);
+		$this->assertTrue($element->hasAttribute('aria-describedby'));
+		$this->assertTrue($element->hasAttribute('aria-label'));
+		$this->assertTrue($element->hasAttribute('aria-orientation'));
+	}
+
+
+	public function testCanRemoveMultipleAriaAttributes()
+	{
+		$element = new Element();
+		$attributes = [
+			'type'             => 'text',
+			'aria-label'       => 'alb',
+			'aria-describedby' => 'adb',
+			'aria-orientation' => 'vertical'
+		];
+		$element->setAttributes($attributes);
+		$element->removeAttributes(['aria-label', 'aria-describedby', 'aria-orientation']);
+		$this->assertFalse($element->hasAttribute('aria-describedby'));
+		$this->assertFalse($element->hasAttribute('aria-label'));
+		$this->assertFalse($element->hasAttribute('aria-orientation'));
+	}
 }

--- a/test/ElementTest.php
+++ b/test/ElementTest.php
@@ -331,7 +331,6 @@ class ElementTest extends TestCase
         $this->assertTrue($element->hasLabelOption('foo3'));
     }
 
-
 	public function testCanAddMultipleAriaAttributes()
 	{
 		$element = new Element();
@@ -346,7 +345,6 @@ class ElementTest extends TestCase
 		$this->assertTrue($element->hasAttribute('aria-label'));
 		$this->assertTrue($element->hasAttribute('aria-orientation'));
 	}
-
 
 	public function testCanRemoveMultipleAriaAttributes()
 	{

--- a/test/ElementTest.php
+++ b/test/ElementTest.php
@@ -330,4 +330,20 @@ class ElementTest extends TestCase
         $this->assertFalse($element->hasLabelOption('foo2'));
         $this->assertTrue($element->hasLabelOption('foo3'));
     }
+
+
+    public function testCanAddMultipleAriaAttributes()
+    {
+        $element = new Element();
+        $attributes = [
+            'type'             => 'text',
+            'aria-label'       => 'alb',
+            'aria-describedby' => 'adb',
+	        'aria-orientation' => 'vertical'
+        ];
+        $element->setAttributes($attributes);
+        $this->assertTrue($element->hasAttribute('aria-describedby'));
+        $this->assertTrue($element->hasAttribute('aria-label'));
+        $this->assertTrue($element->hasAttribute('aria-orientation'));
+    }
 }


### PR DESCRIPTION
This merge request addresses [issue number 37](https://github.com/zendframework/zend-form/issues/37) in the zend-form component repo, and adds all 'aria-*' attributes to the whitelist and removing the previously hard coded 'aria-labelledby' and 'aria-describedby' attributes.