### PR TITLE
Referenze data by validation-group prepare for empty collection.

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -506,7 +506,7 @@ class Form extends Fieldset implements FormInterface
         $validationGroup = $this->getValidationGroup();
         if ($validationGroup !== null) {
             $this->prepareValidationGroup($this, $this->data, $validationGroup);
-            
+
             $filter->setData($this->data);
             $filter->setValidationGroup($validationGroup);
         }

--- a/src/Form.php
+++ b/src/Form.php
@@ -639,12 +639,13 @@ class Form extends Fieldset implements FormInterface
                 }
 
                 $value = $values;
+                
+                if (!isset($data[$key])) {
+                    $data[$key] = [];
+                }
             }
 
-            if (!isset($data[$key])) {
-                $data[$key] = [];
-            }
-            $this->prepareValidationGroup($fieldset, $data[$key], $validationGroup[$key]);
+            $this->prepareValidationGroup($fieldset, (isset($data[$key]))? $data[$key]: [], $validationGroup[$key]);
         }
     }
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -506,6 +506,8 @@ class Form extends Fieldset implements FormInterface
         $validationGroup = $this->getValidationGroup();
         if ($validationGroup !== null) {
             $this->prepareValidationGroup($this, $this->data, $validationGroup);
+            
+            $filter->setData($this->data);
             $filter->setValidationGroup($validationGroup);
         }
 
@@ -613,7 +615,7 @@ class Form extends Fieldset implements FormInterface
      * @param array             $data
      * @param array             $validationGroup
      */
-    protected function prepareValidationGroup(FieldsetInterface $formOrFieldset, array $data, array &$validationGroup)
+    protected function prepareValidationGroup(FieldsetInterface $formOrFieldset, array &$data, array &$validationGroup)
     {
         foreach ($validationGroup as $key => &$value) {
             if (!$formOrFieldset->has($key)) {

--- a/src/Form.php
+++ b/src/Form.php
@@ -639,12 +639,12 @@ class Form extends Fieldset implements FormInterface
                 }
 
                 $value = $values;
-                
+
                 if (!isset($data[$key])) {
                     $data[$key] = [];
                 }
             }
-            
+
             if (isset($data[$key])) {
                 $this->prepareValidationGroup($fieldset, $data[$key], $validationGroup[$key]);
             } else {

--- a/src/Form.php
+++ b/src/Form.php
@@ -644,8 +644,9 @@ class Form extends Fieldset implements FormInterface
                     $data[$key] = [];
                 }
             }
-
-            $this->prepareValidationGroup($fieldset, (isset($data[$key]))? $data[$key]: [], $validationGroup[$key]);
+            
+            $temp = (isset($data[$key]))? $data[$key]: [];
+            $this->prepareValidationGroup($fieldset, $temp, $validationGroup[$key]);
         }
     }
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -645,8 +645,12 @@ class Form extends Fieldset implements FormInterface
                 }
             }
             
-            $temp = (isset($data[$key]))? $data[$key]: [];
-            $this->prepareValidationGroup($fieldset, $temp, $validationGroup[$key]);
+            if (isset($data[$key])) {
+                $this->prepareValidationGroup($fieldset, $data[$key], $validationGroup[$key]);
+            } else {
+                $temp = [];
+                $this->prepareValidationGroup($fieldset, $temp, $validationGroup[$key]);
+            }
         }
     }
 


### PR DESCRIPTION
Is it possible to reference the $data array by Form::prepareValidationGroup to handle empty collections?