### PR TITLE
Pass options to factories as creation options

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -107,7 +107,12 @@ class Factory
         $spec = $this->validateSpecification($spec, __METHOD__);
         $type = isset($spec['type']) ? $spec['type'] : 'Zend\Form\Element';
 
-        $element = $this->getFormElementManager()->get($type);
+        $creationOptions = [];
+        if (isset($spec['options']) && is_array($spec['options'])) {
+            $creationOptions = $spec['options'];
+        }
+
+        $element = $this->getFormElementManager()->get($type, $creationOptions);
 
         if ($element instanceof FormInterface) {
             return $this->configureForm($element, $spec);

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -10,10 +10,12 @@
 namespace ZendTest\Form;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use DateTime;
 use Zend\Filter;
 use Zend\Form;
-use Zend\Form\FormElementManager;
 use Zend\Form\Factory as FormFactory;
+use Zend\Form\FormElementManager;
+use Zend\Form\FormInterface;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Hydrator\HydratorPluginManager;
 
@@ -753,5 +755,31 @@ class FactoryTest extends TestCase
         $this->assertTrue($form->has('bar'));
         $this->assertFalse($form->has('baz'));
         $this->assertTrue($form->has('bat'));
+    }
+
+    public function testOptionsArePassedAsCreationOptionsToFactories()
+    {
+        $formManager = $this->factory->getFormElementManager();
+        $formManager->setFactory('customCreatedForm', TestAsset\CustomCreatedFormFactory::class);
+
+        /* @var $form TestAsset\CustomCreatedForm */
+        $form = $this->factory->create([
+            'name'    => 'some_name',
+            'type'    => 'customCreatedForm',
+            'options' => [
+                'created'           => '2016-02-19',
+                'some_other_option' => 1234
+            ]
+        ]);
+
+        $this->assertInstanceOf(FormInterface::class, $form);
+        $this->assertInstanceOf(TestAsset\CustomCreatedForm::class, $form);
+        $this->assertSame('some_name', $form->getName());
+        $this->assertSame(1234, $form->getOption('some_other_option'));
+
+        /* @var $created DateTime */
+        $created = $form->getCreated();
+        $this->assertInstanceOf(DateTime::class, $created);
+        $this->assertSame('2016-02-19', $created->format('Y-m-d'));
     }
 }

--- a/test/TestAsset/CustomCreatedForm.php
+++ b/test/TestAsset/CustomCreatedForm.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Form\Form;
+use DateTime;
+
+class CustomCreatedForm extends Form
+{
+    private $created;
+
+    public function __construct(DateTime $created, $name = null, $options = array())
+    {
+        parent::__construct($name, $options);
+        $this->created = $created;
+    }
+
+    public function getCreated()
+    {
+        return $this->created;
+    }
+}

--- a/test/TestAsset/CustomCreatedFormFactory.php
+++ b/test/TestAsset/CustomCreatedFormFactory.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\MutableCreationOptionsInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use DateTime;
+
+class CustomCreatedFormFactory implements FactoryInterface, MutableCreationOptionsInterface
+{
+    private $creationOptions = [];
+
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $creationString = 'now';
+        if (isset($this->creationOptions['created'])) {
+            $creationString = $this->creationOptions['created'];
+            unset($this->creationOptions['created']);
+        }
+
+        $created = new DateTime($creationString);
+
+        $name = null;
+        if (isset($this->creationOptions['name'])) {
+            $name = $this->creationOptions['name'];
+            unset($this->creationOptions['name']);
+        }
+
+        $options = $this->creationOptions;
+
+        $form = new CustomCreatedForm($created, $name, $options);
+        return $form;
+    }
+
+    public function setCreationOptions(array $options)
+    {
+        $this->creationOptions = $options;
+    }
+}


### PR DESCRIPTION
Currently it's not possible to pass creation options to factories registered at the `FormElementManager`, when form elements are created by the form factory.

I use factories a lot for creating form elements and atm it's only possible to pass creation options with (inside a `Zend\Form\Form` instance):

```
$this->add($this->factory->getFormElementManager()->get('some_type', [
    'some_option' => 'some_value'
]));
```

Imho options from `create()` should also be passed as creation options to the factories.

This PR makes it possible to short-cut the above to the following:
```
$this->add([
    'type' => 'some_type',
    'options' => [
        'some_option' => 'some_value',
    ]
]);
```

The registered factory for type `some_type` then just need to pass the creation options to the form element.