### PR TITLE
[WIP] Switched Zend code parser for doctrine parser

### DIFF
--- a/src/Annotation/AnnotationBuilder.php
+++ b/src/Annotation/AnnotationBuilder.php
@@ -22,6 +22,7 @@ use Zend\Form\Exception;
 use Zend\Form\Factory;
 use Zend\Form\FormFactoryAwareInterface;
 use Zend\Stdlib\ArrayUtils;
+use Doctrine\Common\Annotations\AnnotationReader;
 
 /**
  * Parses the properties of a class for annotations in order to create a form
@@ -205,23 +206,18 @@ class AnnotationBuilder implements EventManagerAwareInterface, FormFactoryAwareI
         }
 
         $this->entity      = $entity;
-        $annotationManager = $this->getAnnotationManager();
         $formSpec          = new ArrayObject();
         $filterSpec        = new ArrayObject();
 
-        $reflection  = new ClassReflection($entity);
-        $annotations = $reflection->getAnnotations($annotationManager);
+        $reflection = new \ReflectionClass($entity);
+        $reader = new AnnotationReader();
+        $annotations = new AnnotationCollection($reader->getClassAnnotations($reflection));
 
-        if ($annotations instanceof AnnotationCollection) {
-            $this->configureForm($annotations, $reflection, $formSpec, $filterSpec);
-        }
+        $this->configureForm($annotations, $reflection, $formSpec, $filterSpec);
 
         foreach ($reflection->getProperties() as $property) {
-            $annotations = $property->getAnnotations($annotationManager);
-
-            if ($annotations instanceof AnnotationCollection) {
-                $this->configureElement($annotations, $property, $formSpec, $filterSpec);
-            }
+            $annotations = new AnnotationCollection($reader->getPropertyAnnotations($property));
+            $this->configureElement($annotations, $property, $formSpec, $filterSpec);
         }
 
         if (!isset($formSpec['input_filter'])) {


### PR DESCRIPTION
This is a really quick hack to fix PHP 7 (see #51)  causes some (minor) BC breaks, has no tests and the solution could be tidied up a lot more (could re-factor to entirely remove all the zend annotation parsing stuff)

If someone wants to pick this up, I'd be happy to hand it over, otherwise if this is agreed as a reasonable solution going forward, I'll try and find some time to tidy the code up and add tests.
