### PR TITLE
Added FormElementManager alias

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -38,6 +38,7 @@ class ConfigProvider
             'aliases' => [
                 'Zend\Form\Annotation\FormAnnotationBuilder' => 'FormAnnotationBuilder',
                 Annotation\AnnotationBuilder::class => 'FormAnnotationBuilder',
+                FormElementManager::class => 'FormElementManager'
             ],
             'factories' => [
                 'FormAnnotationBuilder' => Annotation\AnnotationBuilderFactory::class,


### PR DESCRIPTION
Added a `FormElementManager` alias for getting the `FormElementManager` per class constant.

```php
$formElementManager = $serviceManager->get(FormElementManager::class);
```

instead of 

```php
$formElementManager = $serviceManager->get('FormElementManager');
```