### PR TITLE
Comprehensive fix for BC breaks introduced since 2.7.1

### DIFF
--- a/autoload/formElementManagerPolyfill.php
+++ b/autoload/formElementManagerPolyfill.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+use Zend\Form\FormElementManager;
+use Zend\ServiceManager\ServiceManager;
+
+call_user_func(function () {
+    $target = method_exists(ServiceManager::class, 'configure')
+        ? FormElementManager\FormElementManagerV3Polyfill::class
+        : FormElementManager\FormElementManagerV2Polyfill::class;
+
+    class_alias($target, FormElementManager::class);
+});

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,10 @@
     "autoload": {
         "psr-4": {
             "Zend\\Form\\": "src/"
-        }
+        },
+        "files": [
+            "autoload/formElementManagerPolyfill.php"
+        ]
     },
     "require": {
         "php": "^5.5 || ^7.0",

--- a/src/Annotation/AnnotationBuilderFactory.php
+++ b/src/Annotation/AnnotationBuilderFactory.php
@@ -10,6 +10,7 @@ namespace Zend\Form\Annotation;
 use Interop\Container\ContainerInterface;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\ListenerAggregateInterface;
+use Zend\Form\Factory;
 use Zend\ServiceManager\Exception\ServiceNotCreatedException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -30,8 +31,7 @@ class AnnotationBuilderFactory implements FactoryInterface
         $eventManager      = $container->get('EventManager');
         $annotationBuilder->setEventManager($eventManager);
 
-        $formElementManager = $container->get('FormElementManager');
-        $formElementManager->injectFactory($container, $annotationBuilder);
+        $this->injectFactory($annotationBuilder->getFormFactory(), $container);
 
         $config = $this->marshalConfig($container);
         if (isset($config['preserve_defined_order'])) {
@@ -134,6 +134,24 @@ class AnnotationBuilderFactory implements FactoryInterface
             }
 
             $listener->attach($events);
+        }
+    }
+
+    /**
+     * Inject the annotation builder's factory instance with the FormElementManager.
+     *
+     * Also injects the factory with the InputFilterManager if present.
+     *
+     * @param Factory $factory
+     * @param ContainerInterface $container
+     */
+    private function injectFactory(Factory $factory, ContainerInterface $container)
+    {
+        $factory->setFormElementManager($container->get('FormElementManager'));
+
+        if ($container->has('InputFilterManager')) {
+            $inputFilters = $container->get('InputFilterManager');
+            $factory->getInputFilterFactory()->setInputFilterManager($inputFilters);
         }
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -108,12 +108,7 @@ class Factory
         $spec = $this->validateSpecification($spec, __METHOD__);
         $type = isset($spec['type']) ? $spec['type'] : Element::class;
 
-        $creationOptions = [];
-        if (isset($spec['options']) && is_array($spec['options'])) {
-            $creationOptions = $spec['options'];
-        }
-
-        $element = $this->getFormElementManager()->get($type, $creationOptions);
+        $element = $this->getFormElementManager()->get($type);
 
         if ($element instanceof FormInterface) {
             return $this->configureForm($element, $spec);

--- a/src/FormElementManager/FormElementManagerTrait.php
+++ b/src/FormElementManager/FormElementManagerTrait.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Form\FormElementManager;
+
+use Zend\Form\Exception;
+
+/**
+ * Trait providing common logic between FormElementManager implementations.
+ *
+ * Trait does not define properties, as the properties common between the
+ * two versions are originally defined in their parent class, causing a
+ * resolution conflict.
+ */
+trait FormElementManagerTrait
+{
+    /**
+     * Retrieve a service from the manager by name
+     *
+     * Allows passing an array of options to use when creating the instance.
+     * createFromInvokable() will use these and pass them to the instance
+     * constructor if not null and a non-empty array.
+     *
+     * @param  string $name
+     * @param  string|array $options
+     * @param  bool $usePeeringServiceManagers
+     * @return object
+     */
+    public function get($name, $options = [], $usePeeringServiceManagers = true)
+    {
+        if (is_string($options)) {
+            $options = ['name' => $options];
+        }
+        return parent::get($name, $options, $usePeeringServiceManagers);
+    }
+
+    /**
+     * Try to pull hydrator from the creation context, or instantiates it from its name
+     *
+     * @param  string $hydratorName
+     * @return mixed
+     * @throws Exception\DomainException
+     */
+    public function getHydratorFromName($hydratorName)
+    {
+        $services = isset($this->creationContext)
+            ? $this->creationContext // v3
+            : $this->serviceLocator; // v2
+
+        if ($services && $services->has('HydratorManager')) {
+            $hydrators = $services->get('HydratorManager');
+            if ($hydrators->has($hydratorName)) {
+                return $hydrators->get($hydratorName);
+            }
+        }
+
+        if ($services && $services->has($hydratorName)) {
+            return $services->get($hydratorName);
+        }
+
+        if (! class_exists($hydratorName)) {
+            throw new Exception\DomainException(sprintf(
+                'Expects string hydrator name to be a valid class name; received "%s"',
+                $hydratorName
+            ));
+        }
+
+        $hydrator = new $hydratorName;
+        return $hydrator;
+    }
+
+    /**
+     * Try to pull factory from the creation context, or instantiates it from its name
+     *
+     * @param  string $factoryName
+     * @return mixed
+     * @throws Exception\DomainException
+     */
+    public function getFactoryFromName($factoryName)
+    {
+        $services = isset($this->creationContext)
+            ? $this->creationContext // v3
+            : $this->serviceLocator; // v2
+
+        if ($services && $services->has($factoryName)) {
+            return $services->get($factoryName);
+        }
+
+        if (! class_exists($factoryName)) {
+            throw new Exception\DomainException(sprintf(
+                'Expects string factory name to be a valid class name; received "%s"',
+                $factoryName
+            ));
+        }
+
+        $factory = new $factoryName;
+        return $factory;
+    }
+}

--- a/src/FormElementManager/FormElementManagerV2Polyfill.php
+++ b/src/FormElementManager/FormElementManagerV2Polyfill.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Form\FormElementManager;
+
+use Interop\Container\ContainerInterface;
+use Zend\Form\Element;
+use Zend\Form\ElementFactory;
+use Zend\Form\ElementInterface;
+use Zend\Form\Exception;
+use Zend\Form\Fieldset;
+use Zend\Form\Form;
+use Zend\Form\FormFactoryAwareInterface;
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\ConfigInterface;
+use Zend\Stdlib\InitializableInterface;
+
+/**
+ * zend-servicemanager v2-compatible plugin manager implementation for form elements.
+ *
+ * Enforces that elements retrieved are instances of ElementInterface.
+ */
+class FormElementManagerV2Polyfill extends AbstractPluginManager
+{
+    use FormElementManagerTrait;
+
+    /**
+     * Aliases for default set of helpers
+     *
+     * @var array
+     */
+    protected $aliases = [
+        'button'         => Element\Button::class,
+        'captcha'        => Element\Captcha::class,
+        'checkbox'       => Element\Checkbox::class,
+        'collection'     => Element\Collection::class,
+        'color'          => Element\Color::class,
+        'csrf'           => Element\Csrf::class,
+        'date'           => Element\Date::class,
+        'dateselect'     => Element\DateSelect::class,
+        'datetime'       => Element\DateTime::class,
+        'datetimelocal'  => Element\DateTimeLocal::class,
+        'datetimeselect' => Element\DateTimeSelect::class,
+        'element'        => Element::class,
+        'email'          => Element\Email::class,
+        'fieldset'       => Fieldset::class,
+        'file'           => Element\File::class,
+        'form'           => Form::class,
+        'hidden'         => Element\Hidden::class,
+        'image'          => Element\Image::class,
+        'month'          => Element\Month::class,
+        'monthselect'    => Element\MonthSelect::class,
+        'MonthSelect'    => Element\MonthSelect::class,
+        'multiCheckbox'  => Element\MultiCheckbox::class,
+        'multiCheckBox'  => Element\MultiCheckbox::class,
+        'number'         => Element\Number::class,
+        'password'       => Element\Password::class,
+        'radio'          => Element\Radio::class,
+        'range'          => Element\Range::class,
+        'select'         => Element\Select::class,
+        'submit'         => Element\Submit::class,
+        'text'           => Element\Text::class,
+        'textarea'       => Element\Textarea::class,
+        'time'           => Element\Time::class,
+        'url'            => Element\Url::class,
+        'week'           => Element\Week::class,
+    ];
+
+    /**
+     * Factories for default set of helpers
+     *
+     * @var array
+     */
+    protected $factories = [
+        Element\Button::class         => ElementFactory::class,
+        Element\Captcha::class        => ElementFactory::class,
+        Element\Checkbox::class       => ElementFactory::class,
+        Element\Collection::class     => ElementFactory::class,
+        Element\Color::class          => ElementFactory::class,
+        Element\Csrf::class           => ElementFactory::class,
+        Element\Date::class           => ElementFactory::class,
+        Element\DateSelect::class     => ElementFactory::class,
+        Element\DateTime::class       => ElementFactory::class,
+        Element\DateTimeLocal::class  => ElementFactory::class,
+        Element\DateTimeSelect::class => ElementFactory::class,
+        Element::class                => ElementFactory::class,
+        Element\Email::class          => ElementFactory::class,
+        Fieldset::class               => ElementFactory::class,
+        Element\File::class           => ElementFactory::class,
+        Form::class                   => ElementFactory::class,
+        Element\Hidden::class         => ElementFactory::class,
+        Element\Image::class          => ElementFactory::class,
+        Element\Month::class          => ElementFactory::class,
+        Element\MonthSelect::class    => ElementFactory::class,
+        Element\MultiCheckbox::class  => ElementFactory::class,
+        Element\Number::class         => ElementFactory::class,
+        Element\Password::class       => ElementFactory::class,
+        Element\Radio::class          => ElementFactory::class,
+        Element\Range::class          => ElementFactory::class,
+        Element\Select::class         => ElementFactory::class,
+        Element\Submit::class         => ElementFactory::class,
+        Element\Text::class           => ElementFactory::class,
+        Element\Textarea::class       => ElementFactory::class,
+        Element\Time::class           => ElementFactory::class,
+        Element\Url::class            => ElementFactory::class,
+        Element\Week::class           => ElementFactory::class,
+
+        // v2 normalized variants
+
+        'zendformelementbutton'         => ElementFactory::class,
+        'zendformelementcaptcha'        => ElementFactory::class,
+        'zendformelementcheckbox'       => ElementFactory::class,
+        'zendformelementcollection'     => ElementFactory::class,
+        'zendformelementcolor'          => ElementFactory::class,
+        'zendformelementcsrf'           => ElementFactory::class,
+        'zendformelementdate'           => ElementFactory::class,
+        'zendformelementdateselect'     => ElementFactory::class,
+        'zendformelementdatetime'       => ElementFactory::class,
+        'zendformelementdatetimelocal'  => ElementFactory::class,
+        'zendformelementdatetimeselect' => ElementFactory::class,
+        'zendformelement'               => ElementFactory::class,
+        'zendformelementemail'          => ElementFactory::class,
+        'zendformfieldset'              => ElementFactory::class,
+        'zendformelementfile'           => ElementFactory::class,
+        'zendformform'                  => ElementFactory::class,
+        'zendformelementhidden'         => ElementFactory::class,
+        'zendformelementimage'          => ElementFactory::class,
+        'zendformelementmonth'          => ElementFactory::class,
+        'zendformelementmonthselect'    => ElementFactory::class,
+        'zendformelementmulticheckbox'  => ElementFactory::class,
+        'zendformelementnumber'         => ElementFactory::class,
+        'zendformelementpassword'       => ElementFactory::class,
+        'zendformelementradio'          => ElementFactory::class,
+        'zendformelementrange'          => ElementFactory::class,
+        'zendformelementselect'         => ElementFactory::class,
+        'zendformelementsubmit'         => ElementFactory::class,
+        'zendformelementtext'           => ElementFactory::class,
+        'zendformelementtextarea'       => ElementFactory::class,
+        'zendformelementtime'           => ElementFactory::class,
+        'zendformelementurl'            => ElementFactory::class,
+        'zendformelementweek'           => ElementFactory::class,
+    ];
+
+    /**
+     * Don't share form elements by default (v3)
+     *
+     * @var bool
+     */
+    protected $sharedByDefault = false;
+
+    /**
+     * Don't share form elements by default (v2)
+     *
+     * @var bool
+     */
+    protected $shareByDefault = false;
+
+    /**
+     * Interface all plugins managed by this class must implement.
+     * @var string
+     */
+    protected $instanceOf = ElementInterface::class;
+
+    /**
+     * Constructor
+     *
+     * Overrides parent constructor in order to add the initializer methods injectFactory()
+     * and callElementInit().
+     *
+     * @param null|ConfigInterface|ContainerInterface $configOrContainerInstance
+     * @param array $v3config If $configOrContainerInstance is a container, this
+     *     value will be passed to the parent constructor.
+     */
+    public function __construct($configInstanceOrParentLocator = null, array $v3config = [])
+    {
+        parent::__construct($configInstanceOrParentLocator, $v3config);
+
+        $this->addInitializer([$this, 'injectFactory']);
+        $this->addInitializer([$this, 'callElementInit'], false);
+    }
+
+    /**
+     * Inject the factory to any element that implements FormFactoryAwareInterface
+     *
+     * @param mixed $instance Instance to inspect and potentially inject.
+     * @param ContainerInterface $container Container passed to initializer.
+     */
+    public function injectFactory($instance, ContainerInterface $container)
+    {
+        // Need to retrieve the parent container
+        $container = $container->getServiceLocator() ?: $container;
+
+        if (! $instance instanceof FormFactoryAwareInterface) {
+            return;
+        }
+
+        $factory = $instance->getFormFactory();
+        $factory->setFormElementManager($this);
+
+        if ($container && $container->has('InputFilterManager')) {
+            $inputFilters = $container->get('InputFilterManager');
+            $factory->getInputFilterFactory()->setInputFilterManager($inputFilters);
+        }
+    }
+
+    /**
+     * Call init() on any element that implements InitializableInterface
+     *
+     * @param mixed $instance Instance to inspect and optionally initialize.
+     * @param ContainerInterface $container
+     */
+    public function callElementInit($instance, ContainerInterface $container)
+    {
+        if ($instance instanceof InitializableInterface) {
+            $instance->init();
+        }
+    }
+
+    /**
+     * Override setInvokableClass
+     *
+     * Overrides setInvokableClass to:
+     *
+     * - add a factory mapping $invokableClass to ElementFactory::class
+     * - alias $name to $invokableClass
+     *
+     * @param string $name
+     * @param string $invokableClass
+     * @param null|bool $shared Ignored.
+     * @return self
+     */
+    public function setInvokableClass($name, $invokableClass, $shared = null)
+    {
+        if (! $this->has($invokableClass)) {
+            $this->setFactory($invokableClass, ElementFactory::class);
+        }
+
+        if ($invokableClass !== $name) {
+            $this->setAlias($name, $invokableClass);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Validate the plugin is of the expected type.
+     *
+     * @param mixed $plugin
+     * @throws Exception\InvalidElementException
+     */
+    public function validatePlugin($plugin)
+    {
+        if (! $plugin instanceof $this->instanceOf) {
+            throw new Exception\InvalidElementException(sprintf(
+                '%s can only create instances of %s; %s is invalid',
+                get_class($this),
+                $this->instanceOf,
+                (is_object($plugin) ? get_class($plugin) : gettype($plugin))
+            ));
+        }
+    }
+}

--- a/test/Annotation/AnnotationBuilderFactoryTest.php
+++ b/test/Annotation/AnnotationBuilderFactoryTest.php
@@ -27,14 +27,10 @@ class AnnotationBuilderFactoryTest extends TestCase
         $events = $this->prophesize(EventManagerInterface::class);
 
         $elements = $this->prophesize(FormElementManager::class);
-        $elements->injectFactory(
-            $container->reveal(),
-            Argument::type(AnnotationBuilder::class)
-        )->shouldBeCalled();
-
         $container->get('EventManager')->willReturn($events->reveal());
         $container->get('FormElementManager')->willReturn($elements->reveal());
         $container->has('config')->willReturn(false);
+        $container->has('InputFilterManager')->willReturn(false);
 
         $factory = new AnnotationBuilderFactory();
         $this->assertInstanceOf(
@@ -49,13 +45,9 @@ class AnnotationBuilderFactoryTest extends TestCase
         $events = $this->prophesize(EventManagerInterface::class);
 
         $elements = $this->prophesize(FormElementManager::class);
-        $elements->injectFactory(
-            $container->reveal(),
-            Argument::type(AnnotationBuilder::class)
-        )->shouldBeCalled();
-
         $container->get('EventManager')->willReturn($events->reveal());
         $container->get('FormElementManager')->willReturn($elements->reveal());
+        $container->has('InputFilterManager')->willReturn(false);
         $container->has('config')->willReturn(true);
         $container->get('config')->willReturn([
             'form_annotation_builder' => [
@@ -75,13 +67,9 @@ class AnnotationBuilderFactoryTest extends TestCase
         $events = $this->prophesize(EventManagerInterface::class);
 
         $elements = $this->prophesize(FormElementManager::class);
-        $elements->injectFactory(
-            $container->reveal(),
-            Argument::type(AnnotationBuilder::class)
-        )->shouldBeCalled();
-
         $container->get('EventManager')->willReturn($events->reveal());
         $container->get('FormElementManager')->willReturn($elements->reveal());
+        $container->has('InputFilterManager')->willReturn(false);
         $container->has('config')->willReturn(true);
         $container->get('config')->willReturn([
             'form_annotation_builder' => [
@@ -110,11 +98,8 @@ class AnnotationBuilderFactoryTest extends TestCase
         $listener->attach($events->reveal())->shouldBeCalled();
 
         $elements = $this->prophesize(FormElementManager::class);
-        $elements->injectFactory(
-            $container->reveal(),
-            Argument::type(AnnotationBuilder::class)
-        )->shouldBeCalled();
 
+        $container->has('InputFilterManager')->willReturn(false);
         $container->get('EventManager')->willReturn($events->reveal());
         $container->get('FormElementManager')->willReturn($elements->reveal());
         $container->has('config')->willReturn(true);
@@ -138,13 +123,10 @@ class AnnotationBuilderFactoryTest extends TestCase
         $listener = $this->prophesize(stdClass::class);
 
         $elements = $this->prophesize(FormElementManager::class);
-        $elements->injectFactory(
-            $container->reveal(),
-            Argument::type(AnnotationBuilder::class)
-        )->shouldBeCalled();
 
         $container->get('EventManager')->willReturn($events->reveal());
         $container->get('FormElementManager')->willReturn($elements->reveal());
+        $container->has('InputFilterManager')->willReturn(false);
         $container->has('config')->willReturn(true);
         $container->get('config')->willReturn([
             'form_annotation_builder' => [

--- a/test/Annotation/AnnotationBuilderFactoryTest.php
+++ b/test/Annotation/AnnotationBuilderFactoryTest.php
@@ -9,7 +9,6 @@ namespace ZendTest\Form\Annotation;
 
 use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase as TestCase;
-use Prophecy\Argument;
 use ReflectionProperty;
 use stdClass;
 use Zend\EventManager\EventManagerInterface;

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -10,12 +10,10 @@
 namespace ZendTest\Form;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use DateTime;
 use Zend\Filter;
 use Zend\Form;
 use Zend\Form\Factory as FormFactory;
 use Zend\Form\FormElementManager;
-use Zend\Form\FormInterface;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Hydrator\HydratorPluginManager;
 
@@ -758,32 +756,6 @@ class FactoryTest extends TestCase
         $this->assertTrue($form->has('bat'));
     }
 
-    public function testOptionsArePassedAsCreationOptionsToFactories()
-    {
-        $formManager = $this->factory->getFormElementManager();
-        $formManager->setFactory('customCreatedForm', TestAsset\CustomCreatedFormFactory::class);
-
-        /* @var $form TestAsset\CustomCreatedForm */
-        $form = $this->factory->create([
-            'name'    => 'some_name',
-            'type'    => 'customCreatedForm',
-            'options' => [
-                'created'           => '2016-02-19',
-                'some_other_option' => 1234
-            ]
-        ]);
-
-        $this->assertInstanceOf(FormInterface::class, $form);
-        $this->assertInstanceOf(TestAsset\CustomCreatedForm::class, $form);
-        $this->assertSame('some_name', $form->getName());
-        $this->assertSame(1234, $form->getOption('some_other_option'));
-
-        /* @var $created DateTime */
-        $created = $form->getCreated();
-        $this->assertInstanceOf(DateTime::class, $created);
-        $this->assertSame('2016-02-19', $created->format('Y-m-d'));
-    }
-
     public function testCanCreateWithConstructionLogicInOptions()
     {
         $formManager = $this->factory->getFormElementManager();
@@ -802,6 +774,7 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(Form\Element\Collection::class, $collection);
 
         $targetElement = $collection->getTargetElement();
+
         $this->assertInstanceOf(TestAsset\FieldsetWithDependency::class, $targetElement);
         $this->assertInstanceOf(TestAsset\InputFilter::class, $targetElement->getDependency());
     }

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -783,4 +783,26 @@ class FactoryTest extends TestCase
         $this->assertInstanceOf(DateTime::class, $created);
         $this->assertSame('2016-02-19', $created->format('Y-m-d'));
     }
+
+    public function testCanCreateWithConstructionLogicInOptions()
+    {
+        $formManager = $this->factory->getFormElementManager();
+        $formManager->setFactory(TestAsset\FieldsetWithDependency::class, TestAsset\FieldsetWithDependencyFactory::class);
+
+        $collection = $this->factory->create([
+            'type' => Form\Element\Collection::class,
+            'name' => 'my_fieldset_collection',
+            'options' => [
+                'target_element' => [
+                    'type' => TestAsset\FieldsetWithDependency::class,
+                ],
+            ],
+        ]);
+
+        $this->assertInstanceOf(Form\Element\Collection::class, $collection);
+
+        $targetElement = $collection->getTargetElement();
+        $this->assertInstanceOf(TestAsset\FieldsetWithDependency::class, $targetElement);
+        $this->assertInstanceOf(TestAsset\InputFilter::class, $targetElement->getDependency());
+    }
 }

--- a/test/FormElementManagerFactoryTest.php
+++ b/test/FormElementManagerFactoryTest.php
@@ -21,7 +21,7 @@ class FormElementManagerFactoryTest extends TestCase
         $container = $this->prophesize(ContainerInterface::class)->reveal();
         $factory = new FormElementManagerFactory();
 
-        $elements = $factory($container, FormElementManagerFactory::class);
+        $elements = $factory($container, FormElementManager::class);
         $this->assertInstanceOf(FormElementManager::class, $elements);
 
         if (method_exists($elements, 'configure')) {
@@ -42,7 +42,7 @@ class FormElementManagerFactoryTest extends TestCase
         $element = $this->prophesize(ElementInterface::class)->reveal();
 
         $factory = new FormElementManagerFactory();
-        $elements = $factory($container, FormElementManagerFactory::class, [
+        $elements = $factory($container, FormElementManager::class, [
             'services' => [
                 'test' => $element,
             ],

--- a/test/FormElementManagerTest.php
+++ b/test/FormElementManagerTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Form;
 
 use ReflectionProperty;
+use Zend\Form\ElementFactory;
 use Zend\Form\Exception\InvalidElementException;
 use Zend\Form\Factory;
 use Zend\Form\Form;
@@ -192,5 +193,32 @@ class FormElementManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertGreaterThan(2, count($actual));
         $last = array_pop($actual);
         $this->assertSame([$manager, 'callElementInit'], $last);
+    }
+
+    /**
+     * @group 62
+     */
+    public function testAddingInvokableCreatesAliasAndMapsClassToElementFactory()
+    {
+        $this->manager->setInvokableClass('foo', TestAsset\ElementWithFilter::class);
+
+        $r = new ReflectionProperty($this->manager, 'aliases');
+        $r->setAccessible(true);
+        $aliases = $r->getValue($this->manager);
+
+        $this->assertArrayHasKey('foo', $aliases);
+        $this->assertEquals(TestAsset\ElementWithFilter::class, $aliases['foo']);
+
+        $r = new ReflectionProperty($this->manager, 'factories');
+        $r->setAccessible(true);
+        $factories = $r->getValue($this->manager);
+
+        if (method_exists($this->manager, 'configure')) {
+            $this->assertArrayHasKey(TestAsset\ElementWithFilter::class, $factories);
+            $this->assertEquals(ElementFactory::class, $factories[TestAsset\ElementWithFilter::class]);
+        } else {
+            $this->assertArrayHasKey('zendtestformtestassetelementwithfilter', $factories);
+            $this->assertEquals(ElementFactory::class, $factories['zendtestformtestassetelementwithfilter']);
+        }
     }
 }

--- a/test/TestAsset/FieldsetWithDependency.php
+++ b/test/TestAsset/FieldsetWithDependency.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Form\Element;
+use Zend\Form\Fieldset;
+
+class FieldsetWithDependency extends Fieldset
+{
+    /**
+     * @var InputFilter
+     */
+    private $dependency;
+
+    public function __construct($name = null, $options = [])
+    {
+        parent::__construct('fielset_with_dependency', $options);
+    }
+    
+    public function init()
+    {
+        // should not fail
+        $this->dependency->getValues();
+    }
+
+    /**
+     * @return InputFilter
+     */
+    public function getDependency()
+    {
+        return $this->dependency;
+    }
+
+    /**
+     * @param InputFilter $dependency
+     */
+    public function setDependency($dependency)
+    {
+        $this->dependency = $dependency;
+    }
+}

--- a/test/TestAsset/FieldsetWithDependency.php
+++ b/test/TestAsset/FieldsetWithDependency.php
@@ -19,7 +19,7 @@ class FieldsetWithDependency extends Fieldset
 
     public function __construct($name = null, $options = [])
     {
-        parent::__construct('fielset_with_dependency', $options);
+        parent::__construct('fieldset_with_dependency', $options);
     }
     
     public function init()

--- a/test/TestAsset/FieldsetWithDependencyFactory.php
+++ b/test/TestAsset/FieldsetWithDependencyFactory.php
@@ -26,9 +26,7 @@ class FieldsetWithDependencyFactory implements FactoryInterface
         }
 
         $form = new FieldsetWithDependency($name, $options);
-        $dependency = new InputFilter();
-        
-        $form->setDependency($dependency);
+        $form->setDependency(new InputFilter());
         
         return $form;
     }

--- a/test/TestAsset/FieldsetWithDependencyFactory.php
+++ b/test/TestAsset/FieldsetWithDependencyFactory.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class FieldsetWithDependencyFactory implements FactoryInterface
+{
+    private $creationOptions = [];
+
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        $options = $options ?: [];
+
+        $name = null;
+        if (isset($options['name'])) {
+            $name = $options['name'];
+            unset($options['name']);
+        }
+
+        $form = new FieldsetWithDependency($name, $options);
+        $dependency = new InputFilter();
+        
+        $form->setDependency($dependency);
+        
+        return $form;
+    }
+
+    public function createService(ServiceLocatorInterface $container)
+    {
+        return $this($container, CustomCreatedForm::class, $this->creationOptions);
+    }
+
+    public function setCreationOptions(array $options)
+    {
+        $this->creationOptions = $options;
+    }
+}


### PR DESCRIPTION
This patch:

- Fixes #66
- Fixes #62
- Fixes #63

Essentially, two principal issues were identified:

- Invokable classes need to use the new `ElementFactory` to ensure they are instantiated correctly. Unfortunately, due to the fact that the "auto add invokables" flag is enabled, and that users can call `setInvokableClass()` or define `invokables` configuration, any such mappings were leading to the classes getting the base zend-servicemanager behavior instead. This patch solves that by creating polyfill solutions for zend-servicemanager v2 and v3 releases, and overriding the `setInvokableClass()` implementations under each to ensure they map invokables to the specialized factory and set any needed aliases. (These polyfills also ensure that the version-specific instantiation rules are present.)
- 2.7.1 specifically broke usage of `Zend\Form\Factory` when using collections, which fetch their target "element" when it's set via options. The break was due to a change in `Zend\Form\Factory::create()`, which was passing discovered options to `FormElementManager::get()`. This led to an order-of-operations issue, as the options were then processed during instantiation, when previously they were processed afterwards, ensuring all setter injections were already complete. The erroneous code was removed.