### PR TITLE
[BC] Add lowercase multicheckbox alias

### DIFF
--- a/src/FormElementManager/FormElementManagerV2Polyfill.php
+++ b/src/FormElementManager/FormElementManagerV2Polyfill.php
@@ -55,6 +55,7 @@ class FormElementManagerV2Polyfill extends AbstractPluginManager
         'month'          => Element\Month::class,
         'monthselect'    => Element\MonthSelect::class,
         'MonthSelect'    => Element\MonthSelect::class,
+        'multicheckbox'  => Element\MultiCheckbox::class,
         'multiCheckbox'  => Element\MultiCheckbox::class,
         'multiCheckBox'  => Element\MultiCheckbox::class,
         'number'         => Element\Number::class,


### PR DESCRIPTION
Small bc break was introduced: string 'MultiCheckbox' doesn't resolve to the MultiCheckbox element anymore using v2 FormElementManager. 

```
$formFactory->create([
    'type' => 'MultiCheckbox',
]);
```

Added lowercase alias for `'MultiCheckBox'`