### PR TITLE
Adds formTextarea alias

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -242,6 +242,7 @@ class ConfigProvider
                 'FormText'                   => View\Helper\FormText::class,
                 'formtextarea'               => View\Helper\FormTextarea::class,
                 'form_text_area'             => View\Helper\FormTextarea::class,
+                'formTextarea'               => View\Helper\FormTextarea::class,
                 'formTextArea'               => View\Helper\FormTextarea::class,
                 'FormTextArea'               => View\Helper\FormTextarea::class,
                 'formtime'                   => View\Helper\FormTime::class,


### PR DESCRIPTION
This alias is missing but used in the documentation:
// Within your view...
echo $this->formTextarea($element);

Reference: http://framework.zend.com/manual/current/en/modules/zend.form.view.helpers.html#formtextarea