### PR TITLE
Fix return type in FormElement#__invoke() docblock

### DIFF
--- a/src/View/Helper/FormElement.php
+++ b/src/View/Helper/FormElement.php
@@ -77,7 +77,7 @@ class FormElement extends BaseAbstractHelper
      * Proxies to {@link render()}.
      *
      * @param  ElementInterface|null $element
-     * @return string|FormElement
+     * @return string
      */
     public function __invoke(ElementInterface $element = null)
     {


### PR DESCRIPTION
Since Zend\Form\View\Helper\FormElement#render() always returns a string, __invoke() must return a string too.