### PR TITLE
FormSelect Helper won't mark value as selected if it is an object

### DIFF
--- a/src/View/Helper/FormSelect.php
+++ b/src/View/Helper/FormSelect.php
@@ -285,7 +285,7 @@ class FormSelect extends AbstractHelper
         }
 
         if (!is_array($value)) {
-            return (array) $value;
+            return (array) (string) $value;
         }
 
         if (!isset($attributes['multiple']) || !$attributes['multiple']) {

--- a/test/TestAsset/Entity/SimpleStringObject.php
+++ b/test/TestAsset/Entity/SimpleStringObject.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset\Entity;
+
+
+class SimpleStringObject
+{
+    public function __toString()
+    {
+        return 'SimpleStringObject';
+    }
+}

--- a/test/View/Helper/FormSelectTest.php
+++ b/test/View/Helper/FormSelectTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Form\View\Helper;
 use Zend\Form\Element;
 use Zend\Form\Element\Select as SelectElement;
 use Zend\Form\View\Helper\FormSelect as FormSelectHelper;
+use ZendTest\Form\TestAsset\Entity\SimpleStringObject;
 
 class FormSelectTest extends CommonTestCase
 {
@@ -407,5 +408,21 @@ class FormSelectTest extends CommonTestCase
 
         $this->setExpectedException('Zend\Form\Exception\DomainException');
         $this->helper->render($element);
+    }
+
+    public function testCanMarkObjectsAsSelected()
+    {
+        $element = new SelectElement('foo');
+        $element->setValueOptions([
+            [
+                'label' => 'SimpleStringObjectLabel',
+                'value' => 'SimpleStringObject',
+            ],
+        ]);
+        $valueObject = new SimpleStringObject();
+        $element->setValue($valueObject);
+
+        $markup = $this->helper->render($element);
+        $this->assertContains('<option value="SimpleStringObject" selected="selected">SimpleStringObjectLabel</option>', $markup);
     }
 }


### PR DESCRIPTION
When working with Doctrine and `Ramsey\UUID` I realized that the FormSelect Helper won't mark values as selected because the selected value is an object of type `Ramsey\UUID` and casting an object to an array didn't get the expected value for me.

I found this in `v2.4.10`.
In which zf2 / zend-form versions would this be fixed (if it will be accepted)?

Best regards
Matthias