### PR TITLE
Form implements InputFilterProviderInterface - validators fix

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -2,8 +2,8 @@
 /**
  * Zend Framework (http://framework.zend.com/)
  *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      http://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -770,6 +770,13 @@ class Form extends Fieldset implements FormInterface
             || ! $fieldset->getTargetElement() instanceof FieldsetInterface
             || $inputFilter instanceof CollectionInputFilter
         ) {
+            if ($fieldset === $this && $fieldset instanceof InputFilterProviderInterface) {
+                foreach ($fieldset->getInputFilterSpecification() as $name => $spec) {
+                    $input = $inputFactory->createInput($spec);
+                    $inputFilter->add($input, $name);
+                }
+            }
+
             foreach ($elements as $name => $element) {
                 if ($this->preferFormInputFilter && $inputFilter->has($name)) {
                     continue;
@@ -798,13 +805,6 @@ class Form extends Fieldset implements FormInterface
                 if ($inputFilter instanceof CollectionInputFilter && ! $inputFilter->getInputFilter()->has($name)) {
                     $inputFilter->getInputFilter()->add($input, $name);
                 } else {
-                    $inputFilter->add($input, $name);
-                }
-            }
-
-            if ($fieldset === $this && $fieldset instanceof InputFilterProviderInterface) {
-                foreach ($fieldset->getInputFilterSpecification() as $name => $spec) {
-                    $input = $inputFactory->createInput($spec);
                     $inputFilter->add($input, $name);
                 }
             }

--- a/test/FieldsetTest.php
+++ b/test/FieldsetTest.php
@@ -2,8 +2,8 @@
 /**
  * Zend Framework (http://framework.zend.com/)
  *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      http://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -571,5 +571,33 @@ class FieldsetTest extends TestCase
         $form->isValid();
 
         $this->assertSame('New value', $form->get('foo')->getValue());
+    }
+
+    public function testInputFilterProviderInterfaceFieldsetCustomElementValidator()
+    {
+        $form = new Form();
+        $form->add(new TestAsset\InputFilterProviderFieldset('fieldset'));
+
+        $inputFilter = $form->getInputFilter();
+        $fieldset = $inputFilter->get('fieldset');
+        $input = $fieldset->get('custom');
+
+        $validators = $input->getValidatorChain()->getValidators();
+        $this->assertCount(1, $validators);
+        $this->assertInstanceOf(TestAsset\CustomValidator::class, $validators[0]['instance']);
+    }
+
+    public function testInputFilterProviderInterfaceFieldsetDefaultElementValidator()
+    {
+        $form = new Form();
+        $form->add(new TestAsset\InputFilterProviderFieldset('fieldset'));
+
+        $inputFilter = $form->getInputFilter();
+        $fieldset = $inputFilter->get('fieldset');
+        $input = $fieldset->get('default');
+
+        $validators = $input->getValidatorChain()->getValidators();
+        $this->assertCount(1, $validators);
+        $this->assertInstanceOf(\Zend\Validator\Step::class, $validators[0]['instance']);
     }
 }

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -2,8 +2,8 @@
 /**
  * Zend Framework (http://framework.zend.com/)
  *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      http://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -2263,5 +2263,29 @@ class FormTest extends TestCase
 
         $this->assertTrue($this->form->isValid());
         $this->assertEquals([], $this->form->getObject()->foo);
+    }
+
+    public function testInputFilterProviderInterfaceFormCustomElementValidator()
+    {
+        $form = new TestAsset\InputFilterProvider();
+
+        $inputFilter = $form->getInputFilter();
+        $input = $inputFilter->get('custom');
+
+        $validators = $input->getValidatorChain()->getValidators();
+        $this->assertCount(1, $validators);
+        $this->assertInstanceOf(TestAsset\CustomValidator::class, $validators[0]['instance']);
+    }
+
+    public function testInputFilterProviderInterfaceFormDefaultElementValidator()
+    {
+        $form = new TestAsset\InputFilterProvider();
+
+        $inputFilter = $form->getInputFilter();
+        $input = $inputFilter->get('default');
+
+        $validators = $input->getValidatorChain()->getValidators();
+        $this->assertCount(1, $validators);
+        $this->assertInstanceOf(\Zend\Validator\Step::class, $validators[0]['instance']);
     }
 }

--- a/test/TestAsset/CustomValidator.php
+++ b/test/TestAsset/CustomValidator.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Validator\ValidatorInterface;
+
+class CustomValidator implements ValidatorInterface
+{
+    public function isValid($value)
+    {
+        return true;
+    }
+
+    public function getMessages()
+    {
+        return [];
+    }
+}

--- a/test/TestAsset/ElementWithStepValidator.php
+++ b/test/TestAsset/ElementWithStepValidator.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Form\Element;
+use Zend\InputFilter\InputProviderInterface;
+use Zend\Validator\Step;
+
+class ElementWithStepValidator extends Element implements InputProviderInterface
+{
+    public function getInputSpecification()
+    {
+        return [
+            'name' => $this->getName(),
+            'validators' => [
+                ['name' => Step::class],
+            ],
+        ];
+    }
+}

--- a/test/TestAsset/InputFilterProvider.php
+++ b/test/TestAsset/InputFilterProvider.php
@@ -2,8 +2,8 @@
 /**
  * Zend Framework (http://framework.zend.com/)
  *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      http://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -21,9 +21,12 @@ class InputFilterProvider extends Form implements InputFilterProviderInterface
         $this->add([
             'name' => 'foo',
             'options' => [
-                'label' => 'Foo'
+                'label' => 'Foo',
             ],
         ]);
+
+        $this->add(new ElementWithStepValidator('custom'));
+        $this->add(new ElementWithStepValidator('default'));
     }
 
     public function getInputFilterSpecification()
@@ -31,7 +34,12 @@ class InputFilterProvider extends Form implements InputFilterProviderInterface
         return [
             'foo' => [
                 'required' => true,
-            ]
+            ],
+            'custom' => [
+                'validators' => [
+                    ['name' => CustomValidator::class],
+                ],
+            ],
         ];
     }
 }

--- a/test/TestAsset/InputFilterProviderFieldset.php
+++ b/test/TestAsset/InputFilterProviderFieldset.php
@@ -2,8 +2,8 @@
 /**
  * Zend Framework (http://framework.zend.com/)
  *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      http://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
@@ -21,9 +21,12 @@ class InputFilterProviderFieldset extends Fieldset implements InputFilterProvide
         $this->add([
             'name' => 'foo',
             'options' => [
-                'label' => 'Foo'
+                'label' => 'Foo',
             ],
         ]);
+
+        $this->add(new ElementWithStepValidator('custom'));
+        $this->add(new ElementWithStepValidator('default'));
 
         $this->add(new BasicFieldset());
     }
@@ -33,7 +36,12 @@ class InputFilterProviderFieldset extends Fieldset implements InputFilterProvide
         return [
             'foo' => [
                 'required' => true,
-            ]
+            ],
+            'custom' => [
+                'validators' => [
+                    ['name' => CustomValidator::class],
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
When Form implements `InputFilterProviderInterface` and validators for an element are defined in method `getInputFilterSpecification`, only these validators should be added to the `InputFilter` of the Form for the element.
The same behavior should be for Fieldsets and it works fine. Basically, validators defined in `getInputFilterSpecification` should override default validators of the Element.
