### PR TITLE
Form collection validation

### DIFF
--- a/test/Element/CollectionTest.php
+++ b/test/Element/CollectionTest.php
@@ -41,6 +41,12 @@ class CollectionTest extends TestCase
         parent::setUp();
     }
 
+    public function testCanRetrieveDefaultPlaceholder()
+    {
+        $placeholder = $this->form->get('colors')->getTemplatePlaceholder();
+        $this->assertEquals('__index__', $placeholder);
+    }
+
     public function testCannotAddNewElementsIfGreaterThanMax()
     {
         $collection = $this->form->get('colors');

--- a/test/Element/CollectionTest.php
+++ b/test/Element/CollectionTest.php
@@ -26,6 +26,7 @@ use ZendTest\Form\TestAsset\Entity\Address;
 use ZendTest\Form\TestAsset\Entity\Phone;
 use ZendTest\Form\TestAsset\Entity\Product;
 use ZendTest\Form\TestAsset\ProductFieldset;
+use Zend\InputFilter\Factory as InputFilterFactory;
 
 class CollectionTest extends TestCase
 {
@@ -40,69 +41,98 @@ class CollectionTest extends TestCase
         parent::setUp();
     }
 
-    public function testCanRetrieveDefaultPlaceholder()
-    {
-        $placeholder = $this->form->get('colors')->getTemplatePlaceholder();
-        $this->assertEquals('__index__', $placeholder);
-    }
-
-    public function testCannotAllowNewElementsIfAllowAddIsFalse()
+    public function testCannotAddNewElementsIfGreaterThanMax()
     {
         $collection = $this->form->get('colors');
-
-        $this->assertTrue($collection->allowAdd());
-        $collection->setAllowAdd(false);
-        $this->assertFalse($collection->allowAdd());
-
-        // By default, $collection contains 2 elements
-        $data = [];
-        $data[] = 'blue';
-        $data[] = 'green';
-
-        $collection->populateValues($data);
-        $this->assertEquals(2, count($collection->getElements()));
-
-        $this->setExpectedException('Zend\Form\Exception\DomainException');
-        $data[] = 'orange';
-        $collection->populateValues($data);
-    }
-
-    public function testCanAddNewElementsIfAllowAddIsTrue()
-    {
-        $collection = $this->form->get('colors');
-        $collection->setAllowAdd(true);
-        $this->assertTrue($collection->allowAdd());
-
-        // By default, $collection contains 2 elements
-        $data = [];
-        $data[] = 'blue';
-        $data[] = 'green';
-
-        $collection->populateValues($data);
-        $this->assertEquals(2, count($collection->getElements()));
-
-        $data[] = 'orange';
-        $collection->populateValues($data);
-        $this->assertEquals(3, count($collection->getElements()));
-    }
-
-    public function testCanRemoveElementsIfAllowRemoveIsTrue()
-    {
-        $collection = $this->form->get('colors');
-        $collection->setAllowRemove(true);
-        $this->assertTrue($collection->allowRemove());
 
         $data = [];
         $data[] = 'blue';
         $data[] = 'green';
 
         $collection->populateValues($data);
-        $this->assertEquals(2, count($collection->getElements()));
 
-        unset($data[0]);
+        $inputFilterFactory = new InputFilterFactory();
+        $inputFilter = $inputFilterFactory->createInputFilter([
+            'colors' => [
+                'name' => 'colors',
+                'validators' => [
+                    [
+                        'name' => 'IterableBetween',
+                        'options' => [
+                            'min' => 1,
+                            'max' => 1
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $collection->setInputFilter($inputFilter);
+        $this->assertFalse($this->form->isValid());
+
+        $messages = $this->form->getMessages();
+        $this->assertArrayHasKey('count', $messages);
+        $this->assertArrayHasKey('notBetween', $messages['count']);
+    }
+
+    public function testCanAddNewElementsIfMaxIsUndefined()
+    {
+        $collection = $this->form->get('colors');
+
+        $data = [];
+        $data[] = 'blue';
+        $data[] = 'green';
 
         $collection->populateValues($data);
-        $this->assertEquals(1, count($collection->getElements()));
+
+        $inputFilterFactory = new InputFilterFactory();
+        $inputFilter = $inputFilterFactory->createInputFilter([
+            'colors' => [
+                'name' => 'colors',
+                'validators' => [
+                    [
+                        'name' => 'IterableBetween',
+                        'options' => [
+                            'min' => 1
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $collection->setInputFilter($inputFilter);
+        $this->assertTrue($this->form->isValid());
+    }
+
+    public function testCollectionCountBetween()
+    {
+        $collection = $this->form->get('colors');
+
+        $data = [];
+        $data[] = 'blue';
+        $data[] = 'green';
+
+        $collection->populateValues($data);
+
+        $inputFilterFactory = new InputFilterFactory();
+        $inputFilter = $inputFilterFactory->createInputFilter([
+            'colors' => [
+                'name' => 'colors',
+                'validators' => [
+                    [
+                        'name' => 'IterableBetween',
+                        'options' => [
+                            'min' => 1,
+                            'max' => 3,
+                            'inclusive' => true
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $collection->setInputFilter($inputFilter);
+        $this->assertTrue($this->form->isValid());
     }
 
     public function testCanReplaceElementsIfAllowAddAndAllowRemoveIsTrue()
@@ -240,36 +270,6 @@ class CollectionTest extends TestCase
         ]);
 
         $this->assertEquals(true, $this->form->isValid());
-    }
-
-    public function testThrowExceptionIfThereAreLessElementsAndAllowRemoveNotAllowed()
-    {
-        $this->setExpectedException('Zend\Form\Exception\DomainException');
-
-        $collection = $this->form->get('colors');
-        $collection->setAllowRemove(false);
-
-        $this->form->setData([
-            'colors' => [
-                '#ffffff'
-            ],
-            'fieldsets' => [
-                [
-                    'field' => 'oneValue',
-                    'nested_fieldset' => [
-                        'anotherField' => 'anotherValue'
-                    ]
-                ],
-                [
-                    'field' => 'twoValue',
-                    'nested_fieldset' => [
-                        'anotherField' => 'anotherValue'
-                    ]
-                ]
-            ]
-        ]);
-
-        $this->form->isValid();
     }
 
     public function testCanValidateLessThanSpecifiedCount()


### PR DESCRIPTION
The updated unit tests shows the use of a new validation class called IterableBetween.  It accepts min, max, and inclusive options, and would behave similarly to Between.  The results from `getMessages` may need to change because it would contain mixture of collection and fieldset errors.

```php
"myCollection": [
    "count": [
        "notBetween": "The input is not between '5' and '10', inclusively"
    ],
    "0": [
        "name": [
            "empty": "Field is required and can't be empty"
        ]
    ],
    "3": [
        "address": [
            "empty": "Field is required and can't be empty"
        ] 
    ]
]
```


