### PR TITLE
Translatable html attributes

### DIFF
--- a/doc/book/helper/abstract-helper.md
+++ b/doc/book/helper/abstract-helper.md
@@ -12,15 +12,19 @@ allows setting a translator and text domain.
 The following public methods are in addition to the inherited methods of
 [Zend\I18n\View\Helper\AbstractTranslatorHelper](http://zendframework.github.io/zend-i18n/view-helpers/#abstract-translator-helper).
 
-Method signature                                       | Description
------------------------------------------------------- | -----------
-`setDoctype(string $doctype) : void`                   | Sets a doctype to use in the helper.
-`getDoctype() : string`                                | Returns the doctype used in the helper.
-`setEncoding(string $encoding) : void`                 | Set the translation text domain to use in helper when translating.
-`getEncoding() : string`                               | Returns the character encoding used in the helper.
-`getId() : string or null`                             | Returns the element id. If no ID attribute present, attempts to use the name attribute. If name attribute is also not present, returns `null`.
-`addTranslatableAttribute(string $attribute): self`    | Marks the given HTML attribute as translatable.
-`addTranslatableAttributePrefix(string $prefix): self` | Marks all HTML attributes that start with the given prefix as translatable.
+Method signature                                               | Description
+-------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------
+`setDoctype(string $doctype) : void`                           | Sets a doctype to use in the helper.
+`getDoctype() : string`                                        | Returns the doctype used in the helper.
+`setEncoding(string $encoding) : void`                         | Set the translation text domain to use in helper when translating.
+`getEncoding() : string`                                       | Returns the character encoding used in the helper.
+`getId() : string or null`                                     | Returns the element id. If no ID attribute present, attempts to use the name attribute. If name attribute is also not present, returns `null`.
+`addTranslatableAttribute(string $attribute) : self`           | Marks the given HTML attribute as translatable.
+`addTranslatableAttributePrefix(string $prefix) : self`        | Marks all HTML attributes that start with the given prefix as translatable.
+`addTranslatableAttribute(string $attribute) : self`           | Marks the given HTML attribute as translatable.
+`addTranslatableAttributePrefix(string $prefix) : self`        | Marks all HTML attributes that start with the given prefix as translatable.
+`addDefaultTranslatableAttribute(string $attribute) : void`    | Marks the given HTML attribute as translatable for all view helpers.
+`addDefaultTranslatableAttributePrefix(string $prefix) : void` | Marks all HTML attributes that start with the given prefix as translatable for all view helpers.
 
 ## Translation
 
@@ -55,4 +59,13 @@ $this->formLabel()->addTranslatableAttribute('data-translate-me');
 
 // mark an prefix as translatable
 $this->formLabel()->addTranslatableAttributePrefix('data-translatable-');
+```
+
+Or you can mark them as translatable for all view helpers (e. g. the title attribute):
+```php
+// mark one attribute as translatable
+\Zend\Form\View\Helper\AbstractHelper->addDefaultTranslatableAttribute('title');
+
+// mark an prefix as translatable
+\Zend\Form\View\Helper\AbstractHelper->addDefaultTranslatableAttributePrefix('data-translatable-');
 ```

--- a/doc/book/helper/abstract-helper.md
+++ b/doc/book/helper/abstract-helper.md
@@ -12,10 +12,47 @@ allows setting a translator and text domain.
 The following public methods are in addition to the inherited methods of
 [Zend\I18n\View\Helper\AbstractTranslatorHelper](http://zendframework.github.io/zend-i18n/view-helpers/#abstract-translator-helper).
 
-Method signature                       | Description
--------------------------------------- | -----------
-`setDoctype(string $doctype) : void`   | Sets a doctype to use in the helper.
-`getDoctype() : string`                | Returns the doctype used in the helper.
-`setEncoding(string $encoding) : void` | Set the translation text domain to use in helper when translating.
-`getEncoding() : string`               | Returns the character encoding used in the helper.
-`getId() : string or null`             | Returns the element id. If no ID attribute present, attempts to use the name attribute. If name attribute is also not present, returns `null`.
+Method signature                                       | Description
+------------------------------------------------------ | -----------
+`setDoctype(string $doctype) : void`                   | Sets a doctype to use in the helper.
+`getDoctype() : string`                                | Returns the doctype used in the helper.
+`setEncoding(string $encoding) : void`                 | Set the translation text domain to use in helper when translating.
+`getEncoding() : string`                               | Returns the character encoding used in the helper.
+`getId() : string or null`                             | Returns the element id. If no ID attribute present, attempts to use the name attribute. If name attribute is also not present, returns `null`.
+`addTranslatableAttribute(string $attribute): self`    | Marks the given HTML attribute as translatable.
+`addTranslatableAttributePrefix(string $prefix): self` | Marks all HTML attributes that start with the given prefix as translatable.
+
+## Translation
+
+Attaching a translator and setting a text domain (using the formLabel view helper as an example):
+
+```php
+// Setting a translator
+$this->formLabel()->setTranslator($translator);
+
+// Setting a text domain
+$this->formLabel()->setTranslatorTextDomain('my-text-domain');
+
+// Setting both
+$this->formLabel()->setTranslator($translator, 'my-text-domain');
+```
+
+> ### Enabling translation
+>
+> If you have a translator in your application container under either the key,
+> `translator` or `MvcTranslator`, the view helper plugin manager will
+> automatically attach the translator to the view helpers.
+
+### What will be translated?
+
+The specific view helpers are responsible to determine what exactly should be translated 
+(e. g. the Label in the FormLabel view helper or the "title" HTML attribute).
+
+If you want to have certain HTML attribute values translated you can mark them as "translatable":
+```php
+// mark one attribute as translatable
+$this->formLabel()->addTranslatableAttribute('data-translate-me');
+
+// mark an prefix as translatable
+$this->formLabel()->addTranslatableAttributePrefix('data-translatable-');
+```

--- a/doc/book/helper/form-label.md
+++ b/doc/book/helper/form-label.md
@@ -58,24 +58,7 @@ echo $this->formLabel($element);
 
 ## Label translation
 
-Attaching a translator and setting a text domain:
-
-```php
-// Setting a translator
-$this->formLabel()->setTranslator($translator);
-
-// Setting a text domain
-$this->formLabel()->setTranslatorTextDomain('my-text-domain');
-
-// Setting both
-$this->formLabel()->setTranslator($translator, 'my-text-domain');
-```
-
-> ### Enabling translation
->
-> If you have a translator in your application container under either the key,
-> `translator` or `MvcTranslator`, the view helper plugin manager will
-> automatically attach the translator to the `FormLabel` view helper.
+See [AbstractHelper Translation](abstract-helper.md#translation).
 
 ## Public methods
 

--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -434,7 +434,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
      *
      * @param string $attribute
      *
-     * @return $this
+     * @return AbstractHelper
      */
     public function addTranslatableAttribute($attribute)
     {
@@ -448,7 +448,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
      *
      * @param string $prefix
      *
-     * @return $this
+     * @return AbstractHelper
      */
     public function addTranslatableAttributePrefix($prefix)
     {

--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -21,6 +21,22 @@ use Zend\View\Helper\EscapeHtmlAttr;
 abstract class AbstractHelper extends BaseAbstractHelper
 {
     /**
+     * The default translatable HTML attributes
+     *
+     * @var array
+     */
+    protected static $defaultTranslatableHtmlAttributes = [
+        'title' => true,
+    ];
+
+    /**
+     * The default translatable HTML attribute prefixes
+     *
+     * @var array
+     */
+    protected static $defaultTranslatableHtmlAttributePrefixes = [];
+
+    /**
      * Standard boolean attributes, with expected values for enabling/disabling
      *
      * @var array
@@ -42,7 +58,6 @@ abstract class AbstractHelper extends BaseAbstractHelper
      */
     protected $translatableAttributes = [
         'placeholder' => true,
-        'title' => true,
     ];
 
     /**
@@ -415,12 +430,18 @@ abstract class AbstractHelper extends BaseAbstractHelper
             return $value;
         }
 
-        if (isset($this->translatableAttributes[$key])) {
+        if (isset($this->translatableAttributes[$key]) || isset(self::$defaultTranslatableHtmlAttributes[$key])) {
             return $this->getTranslator()->translate($value, $this->getTranslatorTextDomain());
         } else {
             foreach ($this->translatableAttributePrefixes as $prefix) {
                 if (mb_substr($key, 0, mb_strlen($prefix)) === $prefix) {
                     // prefix matches => return translated $value
+                    return $this->getTranslator()->translate($value, $this->getTranslatorTextDomain());
+                }
+            }
+            foreach (self::$defaultTranslatableHtmlAttributePrefixes as $prefix) {
+                if (mb_substr($key, 0, mb_strlen($prefix)) === $prefix) {
+                    // default prefix matches => return translated $value
                     return $this->getTranslator()->translate($value, $this->getTranslatorTextDomain());
                 }
             }
@@ -430,7 +451,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
     }
 
     /**
-     * Adds an HTML attribute to the list of translateale attributes
+     * Adds an HTML attribute to the list of translatable attributes
      *
      * @param string $attribute
      *
@@ -444,7 +465,17 @@ abstract class AbstractHelper extends BaseAbstractHelper
     }
 
     /**
-     * Adds an HTML attribute to the list of translateale attributes
+     * Adds an HTML attribute to the list of the default translatable attributes
+     *
+     * @param string $attribute
+     */
+    public static function addDefaultTranslatableAttribute($attribute)
+    {
+        self::$defaultTranslatableHtmlAttributes[$attribute] = true;
+    }
+
+    /**
+     * Adds an HTML attribute to the list of translatable attributes
      *
      * @param string $prefix
      *
@@ -455,5 +486,15 @@ abstract class AbstractHelper extends BaseAbstractHelper
         $this->translatableAttributePrefixes[] = $prefix;
 
         return $this;
+    }
+
+    /**
+     * Adds an HTML attribute to the list of translatable attributes
+     *
+     * @param string $prefix
+     */
+    public static function addDefaultTranslatableAttributePrefix($prefix)
+    {
+        self::$defaultTranslatableHtmlAttributePrefixes[] = $prefix;
     }
 }

--- a/test/View/Helper/AbstractHelperTest.php
+++ b/test/View/Helper/AbstractHelperTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Form\View\Helper;
 
 use Zend\Escaper\Escaper;
+use Zend\Form\View\Helper\AbstractHelper;
 use Zend\I18n\Translator\Translator;
 
 /**
@@ -78,6 +79,48 @@ class AbstractHelperTest extends CommonTestCase
         $this->helper
             ->addTranslatableAttribute('data-translate-me')
             ->addTranslatableAttributePrefix('data-translatable-')
+            ->setTranslatorEnabled(true)
+            ->setTranslator(
+                $translator,
+                'view-helper-text-domain'
+            );
+
+        $this->assertSame(
+            'data-translate-me="Willkommen"',
+            $this->helper->createAttributesString(['data-translate-me' => 'Welcome'])
+        );
+
+        $this->assertSame(
+            'data-translatable-welcome="Willkommen"',
+            $this->helper->createAttributesString(['data-translatable-welcome' => 'Welcome'])
+        );
+
+        $this->assertSame(
+            'class="Welcome"',
+            $this->helper->createAttributesString(['class' => 'Welcome'])
+        );
+    }
+
+    public function testWillTranslateDefaultAttributeValuesCorrectly()
+    {
+        $translator = self::getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['translate'])
+            ->getMock();
+
+        $translator
+            ->expects(self::exactly(2))
+            ->method('translate')
+            ->with(
+                self::equalTo('Welcome'),
+                self::equalTo('view-helper-text-domain')
+            )
+            ->willReturn('Willkommen');
+
+        AbstractHelper::addDefaultTranslatableAttribute('data-translate-me');
+        AbstractHelper::addDefaultTranslatableAttributePrefix('data-translatable-');
+
+        $this->helper
             ->setTranslatorEnabled(true)
             ->setTranslator(
                 $translator,

--- a/test/View/Helper/AbstractHelperTest.php
+++ b/test/View/Helper/AbstractHelperTest.php
@@ -10,6 +10,7 @@
 namespace ZendTest\Form\View\Helper;
 
 use Zend\Escaper\Escaper;
+use Zend\I18n\Translator\Translator;
 
 /**
  * Tests for {@see \Zend\Form\View\Helper\AbstractHelper}
@@ -55,6 +56,47 @@ class AbstractHelperTest extends CommonTestCase
         $this->assertNotSame(
             'data-value="' . $escaper->escapeHtmlAttr('Título') . '"',
             $this->helper->createAttributesString(['data-value' => 'Título'])
+        );
+    }
+
+    public function testWillTranslateAttributeValuesCorrectly()
+    {
+        $translator = self::getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['translate'])
+            ->getMock();
+
+        $translator
+            ->expects(self::exactly(2))
+            ->method('translate')
+            ->with(
+                self::equalTo('Welcome'),
+                self::equalTo('view-helper-text-domain')
+            )
+            ->willReturn('Willkommen');
+
+        $this->helper
+            ->addTranslatableAttribute('data-translate-me')
+            ->addTranslatableAttributePrefix('data-translatable-')
+            ->setTranslatorEnabled(true)
+            ->setTranslator(
+                $translator,
+                'view-helper-text-domain'
+            );
+
+        $this->assertSame(
+            'data-translate-me="Willkommen"',
+            $this->helper->createAttributesString(['data-translate-me' => 'Welcome'])
+        );
+
+        $this->assertSame(
+            'data-translatable-welcome="Willkommen"',
+            $this->helper->createAttributesString(['data-translatable-welcome' => 'Welcome'])
+        );
+
+        $this->assertSame(
+            'class="Welcome"',
+            $this->helper->createAttributesString(['class' => 'Welcome'])
         );
     }
 }


### PR DESCRIPTION
Some HTML attributes are marked as "translatable" (e. g. title and placeholder) and when rendering the view helper will translate the attributes value correctly.

For error messages printed via JS (Parsley to be exact) we're setting the error messages via data- attributes. In order for them to properly translate I've added the ability to add a prefix to the translatable html attributes.

This way we can register "data-translatable-" as prefix for translatable html attributes.

Impact for anybody not using this should be minimal.

I didnt write any tests or documentation for it, but I'm willing to add them if necessary. 
