### PR TITLE
Add InputFilterFactory dependency to constructor

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -32,10 +32,14 @@ class Factory
     /**
      * @param FormElementManager $formElementManager
      */
-    public function __construct(FormElementManager $formElementManager = null)
+    public function __construct(FormElementManager $formElementManager = null, InputFilterFactory $inputFilterFactory = null)
     {
         if ($formElementManager) {
             $this->setFormElementManager($formElementManager);
+        }
+        
+        if($inputFilterFactory) {
+            $this->setInputFilterFactory($inputFilterFactory);
         }
     }
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -37,8 +37,8 @@ class Factory
         if ($formElementManager) {
             $this->setFormElementManager($formElementManager);
         }
-        
-        if($inputFilterFactory) {
+
+        if ($inputFilterFactory) {
             $this->setInputFilterFactory($inputFilterFactory);
         }
     }

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -469,7 +469,7 @@ class FactoryTest extends TestCase
         }
         $this->assertTrue($found);
     }
-    
+
     public function testCanCreateFormFromConcreteClassAndSpecifyCustomValidatorByNameAndSetinputFilterFactoryInConstructor()
     {
         $validatorManager = new \Zend\Validator\ValidatorPluginManager($this->services);
@@ -481,7 +481,7 @@ class FactoryTest extends TestCase
         $inputFilterFactory = new \Zend\InputFilter\Factory();
         $inputFilterFactory->setDefaultValidatorChain($defaultValidatorChain);
 
-        $factory = new FormFactory(null,$inputFilterFactory);
+        $factory = new FormFactory(null, $inputFilterFactory);
 
         $form = $factory->createForm([
             'name'         => 'foo',


### PR DESCRIPTION
The factory currently only had a setInputFilterFactory() method and no way to set it during construction, this change makes the dependency obvious.

This was causing me problems using custom validators until @DASPRiD pointed me towards the method call.
