### PR TITLE
Move Coverage reporting to latest-env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,12 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
-        - TEST_COVERAGE=true
         - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
         - PATH="$HOME/.local/bin:$PATH"
     - php: 5.6
       env:
         - DEPS=latest
+        - TEST_COVERAGE=true
     - php: 7
       env:
         - DEPS=lowest


### PR DESCRIPTION
https://travis-ci.org/zendframework/zend-form/jobs/159520885#L195
Coverage reporting must be moved to latest env since requiring coveralls results in a full update of the dependencies insteaf of using the versions mentioned in the composer.lock