### PR TITLE
set correct Factory when autoAddInvokableClass=true

### DIFF
--- a/src/FormElementManager/FormElementManagerTrait.php
+++ b/src/FormElementManager/FormElementManagerTrait.php
@@ -38,7 +38,7 @@ trait FormElementManagerTrait
 
         if (! $this->has($name)) {
             if (! $this->autoAddInvokableClass || ! class_exists($name)) {
-                throw new Exception\ServiceNotFoundException(sprintf(
+                throw new Exception\InvalidElementException(sprintf(
                     'A plugin by the name "%s" was not found in the plugin manager %s',
                     $name,
                     get_class($this)

--- a/src/FormElementManager/FormElementManagerTrait.php
+++ b/src/FormElementManager/FormElementManagerTrait.php
@@ -35,6 +35,18 @@ trait FormElementManagerTrait
         if (is_string($options)) {
             $options = ['name' => $options];
         }
+
+        if (! $this->has($name)) {
+            if (! $this->autoAddInvokableClass || ! class_exists($name)) {
+                throw new Exception\ServiceNotFoundException(sprintf(
+                    'A plugin by the name "%s" was not found in the plugin manager %s',
+                    $name,
+                    get_class($this)
+                ));
+            }
+
+            $this->setInvokableClass($name, $name);
+        }
         return parent::get($name, $options, $usePeeringServiceManagers);
     }
 

--- a/test/FormElementManagerTest.php
+++ b/test/FormElementManagerTest.php
@@ -224,9 +224,14 @@ class FormElementManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testAutoAddInvokableClass()
     {
-        $instance = $this->manager->get(TestAsset\ConstructedElement::class, ['constructedKey' => 'constructedKey']);
+        $instance = $this->manager->get(
+            TestAsset\ConstructedElement::class,
+            ['constructedKey' => 'constructedKey']
+        );
         $this->assertEquals('constructedelement', $instance->getName());
-        $this->assertEquals(['constructedKey' => 'constructedKey'], $instance->getOptions());
+        $this->assertEquals([
+            'constructedKey' => 'constructedKey'
+        ], $instance->getOptions());
     }
 
     public function testAllAliasesShouldBeCanonicalized()

--- a/test/FormElementManagerTest.php
+++ b/test/FormElementManagerTest.php
@@ -222,6 +222,13 @@ class FormElementManagerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testAutoAddInvokableClass()
+    {
+        $instance = $this->manager->get(TestAsset\ConstructedElement::class, ['constructedKey' => 'constructedKey']);
+        $this->assertEquals('constructedelement', $instance->getName());
+        $this->assertEquals(['constructedKey' => 'constructedKey'], $instance->getOptions());
+    }
+
     public function testAllAliasesShouldBeCanonicalized()
     {
         if (method_exists($this->manager, 'configure')) {

--- a/test/TestAsset/ConstructedElement.php
+++ b/test/TestAsset/ConstructedElement.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Form\Element;
+
+class ConstructedElement extends Element
+{
+    public $constructedKey = null;
+
+    public function __construct($name = null, $options = array())
+    {
+        if (isset($options['constructedKey'])) {
+            $this->constructedKey = $options['constructedKey'];
+        }
+        parent::__construct($name, $options);
+    }
+}

--- a/test/TestAsset/ConstructedElement.php
+++ b/test/TestAsset/ConstructedElement.php
@@ -17,7 +17,7 @@ class ConstructedElement extends Element
      * @param null|int|string $name
      * @param array $options
      */
-    public function __construct($name = null, $options = array())
+    public function __construct($name = null, $options = [])
     {
         if (isset($options['constructedKey'])) {
             $this->constructedKey = $options['constructedKey'];

--- a/test/TestAsset/ConstructedElement.php
+++ b/test/TestAsset/ConstructedElement.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-navigation for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form\TestAsset;
@@ -13,8 +11,12 @@ use Zend\Form\Element;
 
 class ConstructedElement extends Element
 {
-    public $constructedKey = null;
+    public $constructedKey;
 
+    /**
+     * @param null|int|string $name
+     * @param array $options
+     */
     public function __construct($name = null, $options = array())
     {
         if (isset($options['constructedKey'])) {


### PR DESCRIPTION
set correct ``Zend\Form\ElementFactory`` (instead of ``Zend\ServiceManager\Factory\InvokableFactory``) when ``FormElementManager::autoAddInvokableClass = true``.
fix for https://github.com/zendframework/zend-form/issues/114