### PR TITLE
Support Recaptcha APIv2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "doctrine/annotations": "~1.0",
         "zendframework/zend-cache": "^2.6.1",
-        "zendframework/zend-captcha": "^2.7.0",
+        "zendframework/zend-captcha": "^2.7.1",
         "zendframework/zend-code": "^2.6 || ^3.0",
         "zendframework/zend-escaper": "^2.5",
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
@@ -40,7 +40,7 @@
         "phpunit/phpunit": "^4.8"
     },
     "suggest": {
-        "zendframework/zend-captcha": "^2.5.4, required for using CAPTCHA form elements",
+        "zendframework/zend-captcha": "^2.7.1, required for using CAPTCHA form elements",
         "zendframework/zend-code": "^2.6 || ^3.0, required to use zend-form annotations support",
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0, reuired for zend-form annotations support",
         "zendframework/zend-i18n": "^2.6, required when using zend-form view helpers",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "doctrine/annotations": "~1.0",
         "zendframework/zend-cache": "^2.6.1",
-        "zendframework/zend-captcha": "^2.5.4",
+        "zendframework/zend-captcha": "^2.7.0",
         "zendframework/zend-code": "^2.6 || ^3.0",
         "zendframework/zend-escaper": "^2.5",
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
@@ -35,7 +35,7 @@
         "zendframework/zend-text": "^2.6",
         "zendframework/zend-validator": "^2.6",
         "zendframework/zend-view": "^2.6.2",
-        "zendframework/zendservice-recaptcha": "*",
+        "zendframework/zendservice-recaptcha": "^3.0.0",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/phpunit": "^4.8"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bf7dc15eaa3eef472f2e2165750bbe7f",
-    "content-hash": "79b70447a4004b563e0370adef36c323",
+    "content-hash": "b8d176dd4f966a82d5ef216407bea1e5",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -32,7 +31,7 @@
                 "MIT"
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "time": "2014-12-30 15:22:37"
+            "time": "2014-12-30T15:22:37+00:00"
         },
         {
             "name": "zendframework/zend-filter",
@@ -92,7 +91,7 @@
                 "filter",
                 "zf2"
             ],
-            "time": "2016-04-18 18:32:43"
+            "time": "2016-04-18T18:32:43+00:00"
         },
         {
             "name": "zendframework/zend-hydrator",
@@ -154,7 +153,7 @@
                 "hydrator",
                 "zf2"
             ],
-            "time": "2016-04-18 17:59:29"
+            "time": "2016-04-18T17:59:29+00:00"
         },
         {
             "name": "zendframework/zend-inputfilter",
@@ -209,7 +208,7 @@
                 "inputfilter",
                 "zf2"
             ],
-            "time": "2016-06-11 19:35:33"
+            "time": "2016-06-11T19:35:33+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -254,7 +253,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-04-12 21:19:36"
+            "time": "2016-04-12T21:19:36+00:00"
         },
         {
             "name": "zendframework/zend-validator",
@@ -325,7 +324,7 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2016-06-23 13:44:31"
+            "time": "2016-06-23T13:44:31+00:00"
         }
     ],
     "packages-dev": [
@@ -395,7 +394,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2015-08-31T12:32:49+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -449,7 +448,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -503,7 +502,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2014-09-09T13:34:57+00:00"
         },
         {
             "name": "fabpot/php-cs-fixer",
@@ -558,7 +557,7 @@
             ],
             "description": "A script to automatically fix Symfony Coding Standard",
             "abandoned": "friendsofphp/php-cs-fixer",
-            "time": "2015-05-04 16:56:09"
+            "time": "2015-05-04T16:56:09+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -606,7 +605,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-04-03 06:00:07"
+            "time": "2016-04-03T06:00:07+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -660,7 +659,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -705,7 +704,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-06-10 09:48:41"
+            "time": "2016-06-10T09:48:41+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -752,7 +751,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2016-06-10T07:14:17+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -814,7 +813,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07 08:13:47"
+            "time": "2016-06-07T08:13:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -876,7 +875,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -923,7 +922,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2015-06-21T13:08:43+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -964,7 +963,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -1008,7 +1007,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -1057,7 +1056,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2015-09-15T10:49:45+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1129,7 +1128,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-17 03:09:28"
+            "time": "2016-05-17T03:09:28+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1185,7 +1184,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1249,7 +1248,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2015-07-26T15:48:44+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1301,7 +1300,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1351,7 +1350,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-05-17 03:18:57"
+            "time": "2016-05-17T03:18:57+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1418,7 +1417,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1469,7 +1468,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1522,7 +1521,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2015-11-11T19:50:13+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1557,7 +1556,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "symfony/console",
@@ -1617,7 +1616,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-06 15:06:25"
+            "time": "2016-06-06T15:06:25+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1677,7 +1676,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-06 11:11:27"
+            "time": "2016-06-06T11:11:27+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -1726,7 +1725,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-04-12 18:01:21"
+            "time": "2016-04-12T18:01:21+00:00"
         },
         {
             "name": "symfony/finder",
@@ -1775,7 +1774,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-06 11:11:27"
+            "time": "2016-06-06T11:11:27+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1834,7 +1833,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-05-18T14:26:46+00:00"
         },
         {
             "name": "symfony/process",
@@ -1883,7 +1882,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-06 11:11:27"
+            "time": "2016-06-06T11:11:27+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -1932,7 +1931,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-06 11:11:27"
+            "time": "2016-06-06T11:11:27+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1981,7 +1980,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-14 11:18:07"
+            "time": "2016-06-14T11:18:07+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2030,7 +2029,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2015-08-24 13:29:44"
+            "time": "2015-08-24T13:29:44+00:00"
         },
         {
             "name": "zendframework/zend-cache",
@@ -2099,20 +2098,20 @@
                 "cache",
                 "zf2"
             ],
-            "time": "2016-05-12 21:47:55"
+            "time": "2016-05-12T21:47:55+00:00"
         },
         {
             "name": "zendframework/zend-captcha",
-            "version": "2.6.0",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-captcha.git",
-                "reference": "9a1197bc5b8aa4fad104c22f6d9b2a3d4bdda0c6"
+                "reference": "d2809f1dc4bad4d00613398dd0db14d74335ad7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-captcha/zipball/9a1197bc5b8aa4fad104c22f6d9b2a3d4bdda0c6",
-                "reference": "9a1197bc5b8aa4fad104c22f6d9b2a3d4bdda0c6",
+                "url": "https://api.github.com/repos/zendframework/zend-captcha/zipball/d2809f1dc4bad4d00613398dd0db14d74335ad7a",
+                "reference": "d2809f1dc4bad4d00613398dd0db14d74335ad7a",
                 "shasum": ""
             },
             "require": {
@@ -2122,11 +2121,11 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.8",
-                "squizlabs/php_codesniffer": "^2.3.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-session": "^2.6",
                 "zendframework/zend-text": "^2.6",
                 "zendframework/zend-validator": "^2.6",
-                "zendframework/zendservice-recaptcha": "*"
+                "zendframework/zendservice-recaptcha": "^3.0"
             },
             "suggest": {
                 "zendframework/zend-i18n-resources": "Translations of captcha messages",
@@ -2138,8 +2137,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev",
-                    "dev-develop": "2.7-dev"
+                    "dev-master": "2.7-dev",
+                    "dev-develop": "2.8-dev"
                 }
             },
             "autoload": {
@@ -2156,7 +2155,7 @@
                 "captcha",
                 "zf2"
             ],
-            "time": "2016-06-21 17:32:09"
+            "time": "2017-02-20T13:13:57+00:00"
         },
         {
             "name": "zendframework/zend-code",
@@ -2209,7 +2208,7 @@
                 "code",
                 "zf2"
             ],
-            "time": "2016-04-20 17:34:49"
+            "time": "2016-04-20T17:34:49+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -2253,7 +2252,7 @@
                 "escaper",
                 "zf2"
             ],
-            "time": "2015-06-03 14:05:37"
+            "time": "2015-06-03T14:05:37+00:00"
         },
         {
             "name": "zendframework/zend-eventmanager",
@@ -2307,7 +2306,7 @@
                 "events",
                 "zf2"
             ],
-            "time": "2016-02-18 20:53:00"
+            "time": "2016-02-18T20:53:00+00:00"
         },
         {
             "name": "zendframework/zend-http",
@@ -2357,7 +2356,7 @@
                 "http",
                 "zf2"
             ],
-            "time": "2016-02-04 20:36:48"
+            "time": "2016-02-04T20:36:48+00:00"
         },
         {
             "name": "zendframework/zend-i18n",
@@ -2424,7 +2423,7 @@
                 "i18n",
                 "zf2"
             ],
-            "time": "2016-06-07 21:08:30"
+            "time": "2016-06-07T21:08:30+00:00"
         },
         {
             "name": "zendframework/zend-json",
@@ -2479,7 +2478,7 @@
                 "json",
                 "zf2"
             ],
-            "time": "2016-02-04 21:20:26"
+            "time": "2016-02-04T21:20:26+00:00"
         },
         {
             "name": "zendframework/zend-loader",
@@ -2523,7 +2522,7 @@
                 "loader",
                 "zf2"
             ],
-            "time": "2015-06-03 14:05:47"
+            "time": "2015-06-03T14:05:47+00:00"
         },
         {
             "name": "zendframework/zend-math",
@@ -2573,7 +2572,7 @@
                 "math",
                 "zf2"
             ],
-            "time": "2016-04-28 17:37:42"
+            "time": "2016-04-28T17:37:42+00:00"
         },
         {
             "name": "zendframework/zend-servicemanager",
@@ -2628,7 +2627,7 @@
                 "servicemanager",
                 "zf"
             ],
-            "time": "2016-06-01 16:50:58"
+            "time": "2016-06-01T16:50:58+00:00"
         },
         {
             "name": "zendframework/zend-session",
@@ -2694,7 +2693,7 @@
                 "session",
                 "zf2"
             ],
-            "time": "2016-06-24 15:52:13"
+            "time": "2016-06-24T15:52:13+00:00"
         },
         {
             "name": "zendframework/zend-text",
@@ -2741,7 +2740,7 @@
                 "text",
                 "zf2"
             ],
-            "time": "2016-02-08 19:03:52"
+            "time": "2016-02-08T19:03:52+00:00"
         },
         {
             "name": "zendframework/zend-uri",
@@ -2788,7 +2787,7 @@
                 "uri",
                 "zf2"
             ],
-            "time": "2016-02-17 22:38:51"
+            "time": "2016-02-17T22:38:51+00:00"
         },
         {
             "name": "zendframework/zend-version",
@@ -2838,7 +2837,7 @@
                 "version",
                 "zf2"
             ],
-            "time": "2015-06-04 15:41:05"
+            "time": "2015-06-04T15:41:05+00:00"
         },
         {
             "name": "zendframework/zend-view",
@@ -2925,37 +2924,46 @@
                 "view",
                 "zf2"
             ],
-            "time": "2016-06-21 20:58:34"
+            "time": "2016-06-21T20:58:34+00:00"
         },
         {
             "name": "zendframework/zendservice-recaptcha",
-            "version": "2.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/ZendService_ReCaptcha.git",
-                "reference": "4324cca8502d9f47b3b43a18acdd3fdbeb965536"
+                "reference": "6c6877c07c8ac73b187911ea5d264a640b234361"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/ZendService_ReCaptcha/zipball/4324cca8502d9f47b3b43a18acdd3fdbeb965536",
-                "reference": "4324cca8502d9f47b3b43a18acdd3fdbeb965536",
+                "url": "https://api.github.com/repos/zendframework/ZendService_ReCaptcha/zipball/6c6877c07c8ac73b187911ea5d264a640b234361",
+                "reference": "6c6877c07c8ac73b187911ea5d264a640b234361",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "zendframework/zend-http": ">=2.0.0",
-                "zendframework/zend-uri": ">=2.0.0",
-                "zendframework/zend-version": ">=2.0.0"
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-json": "^2.6.1 || ^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-config": "^2.0",
+                "zendframework/zend-validator": "^2.8.2"
+            },
+            "suggest": {
+                "zendframework/zend-validator": "~2.0, if using ReCaptcha's Mailhide API"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "ZendService": "library/"
+                "psr-4": {
+                    "ZendService\\ReCaptcha\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2968,7 +2976,7 @@
                 "recaptcha",
                 "zf2"
             ],
-            "time": "2012-09-24 15:18:29"
+            "time": "2017-02-09T21:38:25+00:00"
         }
     ],
     "aliases": [],

--- a/src/View/Helper/Captcha/ReCaptcha.php
+++ b/src/View/Helper/Captcha/ReCaptcha.php
@@ -55,24 +55,39 @@ class ReCaptcha extends FormInput
         $name = $element->getName();
 
         $markup = $captcha->getService()->getHtml($name);
+        $hidden = $this->renderHiddenInput($name);
 
-        return $markup;
+        return $hidden . $markup;
     }
 
     /**
-     * No longer used with v2 of Recaptcha API
+     * Render hidden input element if the element's name is not 'g-recaptcha-response'
+     * so that required validation works
      *
-     * @deprecated
+     * Note that only the first parameter is needed, the other three parameters
+     * are deprecated.
      *
-     * @param  string $challengeName
-     * @param  string $challengeId
-     * @param  string $responseName
-     * @param  string $responseId
+     * @param  string $name
+     * @param  string $challengeId @deprecated
+     * @param  string $responseName @deprecated
+     * @param  string $responseId @deprecated
      * @return string
      */
-    protected function renderHiddenInput($challengeName, $challengeId, $responseName, $responseId)
+    protected function renderHiddenInput($name, $challengeId = '', $responseName = '', $responseId = '')
     {
-        return '';
+        if ($name === 'g-recaptcha-response') {
+            return '';
+        }
+
+        $pattern        = '<input type="hidden" %s%s';
+        $closingBracket = $this->getInlineClosingBracket();
+
+        $attributes = $this->createAttributesString([
+            'name'  => $name,
+            'value' => 'g-recaptcha-response',
+        ]);
+        $challenge = sprintf($pattern, $attributes, $closingBracket);
+        return $challenge;
     }
 
     /**

--- a/src/View/Helper/Captcha/ReCaptcha.php
+++ b/src/View/Helper/Captcha/ReCaptcha.php
@@ -52,22 +52,17 @@ class ReCaptcha extends FormInput
             ));
         }
 
-        $name          = $element->getName();
-        $id            = isset($attributes['id']) ? $attributes['id'] : $name;
-        $challengeName = empty($name) ? 'recaptcha_challenge_field' : $name . '[recaptcha_challenge_field]';
-        $responseName  = empty($name) ? 'recaptcha_response_field'  : $name . '[recaptcha_response_field]';
-        $challengeId   = $id . '-challenge';
-        $responseId    = $id . '-response';
+        $name = $element->getName();
 
         $markup = $captcha->getService()->getHtml($name);
-        $hidden = $this->renderHiddenInput($challengeName, $challengeId, $responseName, $responseId);
-        $js     = $this->renderJsEvents($challengeId, $responseId);
 
-        return $hidden . $markup . $js;
+        return $markup;
     }
 
     /**
-     * Render hidden input elements for the challenge and response
+     * No longer used with v2 of Recaptcha API
+     *
+     * @deprecated
      *
      * @param  string $challengeName
      * @param  string $challengeId
@@ -77,26 +72,13 @@ class ReCaptcha extends FormInput
      */
     protected function renderHiddenInput($challengeName, $challengeId, $responseName, $responseId)
     {
-        $pattern        = '<input type="hidden" %s%s';
-        $closingBracket = $this->getInlineClosingBracket();
-
-        $attributes = $this->createAttributesString([
-            'name' => $challengeName,
-            'id'   => $challengeId,
-        ]);
-        $challenge = sprintf($pattern, $attributes, $closingBracket);
-
-        $attributes = $this->createAttributesString([
-            'name' => $responseName,
-            'id'   => $responseId,
-        ]);
-        $response = sprintf($pattern, $attributes, $closingBracket);
-
-        return $challenge . $response;
+        return '';
     }
 
     /**
-     * Create the JS events used to bind the challenge and response values to the submitted form.
+     * No longer used with v2 of Recaptcha API
+     *
+     * @deprecated
      *
      * @param  string $challengeId
      * @param  string $responseId
@@ -104,39 +86,6 @@ class ReCaptcha extends FormInput
      */
     protected function renderJsEvents($challengeId, $responseId)
     {
-        $elseif = 'else if'; // php-cs-fixer bug
-        $js =<<<EOJ
-<script type="text/javascript" language="JavaScript">
-function windowOnLoad(fn)
-{
-    var old = window.onload;
-    window.onload = function () {
-        if (old) {
-            old();
-        }
-        fn();
-    };
-}
-function zendBindEvent(el, eventName, eventHandler)
-{
-    if (el.addEventListener) {
-        el.addEventListener(eventName, eventHandler, false);
-    } $elseif (el.attachEvent) {
-        el.attachEvent('on'+eventName, eventHandler);
-    }
-}
-windowOnLoad(function () {
-    zendBindEvent(
-        document.getElementById("$challengeId").form,
-        'submit',
-        function (e) {
-            document.getElementById("$challengeId").value = document.getElementById("recaptcha_challenge_field").value;
-            document.getElementById("$responseId").value = document.getElementById("recaptcha_response_field").value;
-        }
-    );
-});
-</script>
-EOJ;
-        return $js;
+        return '';
     }
 }

--- a/test/View/Helper/Captcha/ReCaptchaTest.php
+++ b/test/View/Helper/Captcha/ReCaptchaTest.php
@@ -31,9 +31,8 @@ class ReCaptchaTest extends CommonTestCase
 
         $this->helper  = new ReCaptchaHelper();
         $this->captcha = new ReCaptcha();
-        $service = $this->captcha->getService();
-        $service->setPublicKey(getenv('TESTS_ZEND_FORM_RECAPTCHA_PUBLIC_KEY'));
-        $service->setPrivateKey(getenv('TESTS_ZEND_FORM_RECAPTCHA_PRIVATE_KEY'));
+        $this->captcha->setPubKey(getenv('TESTS_ZEND_FORM_RECAPTCHA_PUBLIC_KEY'));
+        $this->captcha->setPrivKey(getenv('TESTS_ZEND_FORM_RECAPTCHA_PRIVATE_KEY'));
         parent::setUp();
     }
 
@@ -52,62 +51,10 @@ class ReCaptchaTest extends CommonTestCase
         $this->helper->render($element);
     }
 
-    public function testRendersHiddenInputForChallengeField()
-    {
-        $element = $this->getElement();
-        $markup  = $this->helper->render($element);
-        $this->assertRegExp(
-            '#(type="hidden").*?(name="' . $element->getName() . '\&\#x5B;recaptcha_challenge_field\&\#x5D;")#',
-            $markup
-        );
-        $this->assertRegExp('#(type="hidden").*?(id="' . $element->getName() . '-challenge")#', $markup);
-    }
-
-    public function testRendersNoscriptTextareaForChallengeField()
-    {
-        $element = $this->getElement();
-        $markup  = $this->helper->render($element);
-        $this->assertRegExp(
-            '#textarea.*?(name="' . $element->getName() . '\[recaptcha_challenge_field\]")#',
-            $markup
-        );
-    }
-
-    public function testRendersHiddenInputForResponseField()
-    {
-        $element = $this->getElement();
-        $markup  = $this->helper->render($element);
-        $this->assertRegExp(
-            '#(type="hidden")[^>]*?(name="' . $element->getName() . '\&\#x5B;recaptcha_response_field\&\#x5D;")'
-            . '[^>]*?(id="' . $element->getName() . '-response")#',
-            $markup
-        );
-    }
-
-    public function testRendersNoscriptHiddenInputForResponseField()
-    {
-        $element = $this->getElement();
-        $markup  = $this->helper->render($element);
-        $this->assertRegExp(
-            '#(type="hidden")[^>]*?(name="' . $element->getName() . '\[recaptcha_response_field\]")'
-            . '[^>]*?(value="manual_challenge")#',
-            $markup
-        );
-    }
-
     public function testRendersReCaptchaMarkup()
     {
         $element = $this->getElement();
         $markup  = $this->helper->render($element);
         $this->assertContains($this->captcha->getService()->getHtml($element->getName()), $markup);
-    }
-
-    public function testRendersJsEventScripts()
-    {
-        $element = $this->getElement();
-        $markup  = $this->helper->render($element);
-        $this->assertContains('function zendBindEvent', $markup);
-        $this->assertContains('document.getElementById("' . $element->getName() . '-challenge")', $markup);
-        $this->assertContains('document.getElementById("' . $element->getName() . '-response")', $markup);
     }
 }

--- a/test/View/Helper/Captcha/ReCaptchaTest.php
+++ b/test/View/Helper/Captcha/ReCaptchaTest.php
@@ -51,6 +51,22 @@ class ReCaptchaTest extends CommonTestCase
         $this->helper->render($element);
     }
 
+    public function testRendersHiddenInputWhenNameIsNotRecaptchaDefault()
+    {
+        $element = $this->getElement();
+        $markup  = $this->helper->render($element);
+        $this->assertContains('type="hidden"', $markup);
+        $this->assertContains('value="g-recaptcha-response"', $markup);
+    }
+
+    public function testDoesNotRenderHiddenInputWhenNameIsRecaptchaDefault()
+    {
+        $element = $this->getElement();
+        $element->setName('g-recaptcha-response');
+        $markup  = $this->helper->render($element);
+        $this->assertNotContains('type="hidden"', $markup);
+    }
+
     public function testRendersReCaptchaMarkup()
     {
         $element = $this->getElement();

--- a/test/View/Helper/FormCaptchaTest.php
+++ b/test/View/Helper/FormCaptchaTest.php
@@ -147,18 +147,12 @@ class FormCaptchaTest extends CommonTestCase
         }
 
         $captcha = new Captcha\ReCaptcha();
-        $service = $captcha->getService();
-        $service->setPublicKey(getenv('TESTS_ZEND_FORM_RECAPTCHA_PUBLIC_KEY'));
-        $service->setPrivateKey(getenv('TESTS_ZEND_FORM_RECAPTCHA_PRIVATE_KEY'));
+        $captcha->setPubKey(getenv('TESTS_ZEND_FORM_RECAPTCHA_PUBLIC_KEY'));
+        $captcha->setPrivKey(getenv('TESTS_ZEND_FORM_RECAPTCHA_PRIVATE_KEY'));
 
         $element = $this->getElement();
         $element->setCaptcha($captcha);
         $markup = $this->helper->render($element);
-        $this->assertContains('foo-challenge', $markup);
-        $this->assertContains('foo-response', $markup);
-        $this->assertContains('foo[recaptcha_challenge_field]', $markup);
-        $this->assertContains('foo[recaptcha_response_field]', $markup);
-        $this->assertContains('zendBindEvent', $markup);
-        $this->assertContains($service->getHtml('foo'), $markup);
+        $this->assertContains('data-sitekey="' . getenv('TESTS_ZEND_FORM_RECAPTCHA_PUBLIC_KEY') . '"', $markup);
     }
 }


### PR DESCRIPTION
Update to use zend-capchta:2.7.0 which require zendservice-recaptcha:3.0.0

From zend-form's point of view, we no longer need a hidden field or the JS. As a result, `renderHiddenInput()` and `renderJsEvents()` are now just stubbed out and marked deprecated.