### PR TITLE
[Bugfix] Check if container contains method before calling it

### DIFF
--- a/src/FormElementManager/FormElementManagerV2Polyfill.php
+++ b/src/FormElementManager/FormElementManagerV2Polyfill.php
@@ -17,6 +17,7 @@ use Zend\Form\Form;
 use Zend\Form\FormFactoryAwareInterface;
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\ConfigInterface;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\Stdlib\InitializableInterface;
 
 /**
@@ -191,7 +192,9 @@ class FormElementManagerV2Polyfill extends AbstractPluginManager
     public function injectFactory($instance, ContainerInterface $container)
     {
         // Need to retrieve the parent container
-        $container = $container->getServiceLocator() ?: $container;
+        if ($container instanceof ServiceLocatorAwareInterface || method_exists($container, 'getServiceLocator')) {
+            $container = $container->getServiceLocator() ?: $container;
+        }
 
         if (! $instance instanceof FormFactoryAwareInterface) {
             return;


### PR DESCRIPTION
Do not blindly call `getServiceLocator` on `ContainerInterface` which must not implement that method. 