### PR TITLE
spelling fixes

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -495,7 +495,7 @@ class Factory
 
         if (! $factoryOrName instanceof Factory) {
             throw new Exception\DomainException(sprintf(
-                '%s expects a valid extention of Zend\Form\Factory; received "%s"',
+                '%s expects a valid extension of Zend\Form\Factory; received "%s"',
                 $method,
                 $factoryOrName
             ));

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -2257,7 +2257,7 @@ class FormTest extends TestCase
         $this->form->setData([
             'submit' => 'Confirm',
             'example' => [
-                //'foo' => [] // $_POST does't have this if collection is empty
+                //'foo' => [] // $_POST doesn't have this if collection is empty
             ]
         ]);
 


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.