### PR TITLE
Fix how inputs for elements nested in collections are merged

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -792,6 +792,19 @@ class Form extends Fieldset implements FormInterface
                         $inputFilter->replace($input, $name);
                         continue;
                     }
+
+                    // If we are dealing with a collection input filter, check
+                    // the input filter it composes for an element of the same
+                    // name as was done above.
+                    if ($inputFilter instanceof CollectionInputFilter
+                        && $inputFilter->getInputFilter()->has($name)
+                        && $inputFilter->getInputFilter() instanceof ReplaceableInputInterface
+                    ) {
+                        $collectionInputFilter = $inputFilter->getInputFilter();
+                        $input->merge($collectionInputFilter->get($name));
+                        $collectionInputFilter->replace($input, $name);
+                        continue;
+                    }
                 }
 
                 // Add element input filter to CollectionInputFilter

--- a/test/Integration/FormCreatesCollectionInputFilterTest.php
+++ b/test/Integration/FormCreatesCollectionInputFilterTest.php
@@ -17,11 +17,13 @@ class FormCreatesCollectionInputFilterTest extends TestCase
     public static function assertValidatorFound($class, array $validators, $message = null)
     {
         $message = $message ?: sprintf('Failed to find validator of type %s in validator list', $class);
-        foreach ($validators as $validator) {
+        foreach ($validators as $instance) {
+            $validator = $instance['instance'];
             if ($validator instanceof $class) {
                 return true;
             }
         }
+        var_export($validators);
         self::fail($message);
     }
 
@@ -63,7 +65,7 @@ class FormCreatesCollectionInputFilterTest extends TestCase
         $this->assertCount(3, $validators);
         $this->assertValidatorFound(Validator\StringLength::class, $validators);
         $this->assertValidatorFound(Validator\Date::class, $validators);
-        $this->assertValidatorFound(Validator\Step::class, $validators);
+        $this->assertValidatorFound(Validator\DateStep::class, $validators);
 
         return $form;
     }

--- a/test/Integration/FormCreatesCollectionInputFilterTest.php
+++ b/test/Integration/FormCreatesCollectionInputFilterTest.php
@@ -64,5 +64,16 @@ class FormCreatesCollectionInputFilterTest extends TestCase
         $this->assertValidatorFound(Validator\StringLength::class, $validators);
         $this->assertValidatorFound(Validator\Date::class, $validators);
         $this->assertValidatorFound(Validator\Step::class, $validators);
+
+        return $form;
+    }
+
+    /**
+     * @depends testCollectionInputFilterContainsExpectedValidators
+     */
+    public function testCollectionElementDoesNotCreateDiscreteElementInInputFilter(Form $form)
+    {
+        $inputFilter = $form->getInputFilter();
+        $this->assertFalse($inputFilter->has('date'));
     }
 }

--- a/test/Integration/FormCreatesCollectionInputFilterTest.php
+++ b/test/Integration/FormCreatesCollectionInputFilterTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Form\Integration;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Form\Form;
+use Zend\Form\InputFilterProviderFieldset;
+use Zend\Validator;
+
+class FormCreatesCollectionInputFilterTest extends TestCase
+{
+    public static function assertValidatorFound($class, array $validators, $message = null)
+    {
+        $message = $message ?: sprintf('Failed to find validator of type %s in validator list', $class);
+        foreach ($validators as $validator) {
+            if ($validator instanceof $class) {
+                return true;
+            }
+        }
+        self::fail($message);
+    }
+
+    /**
+     * @see https://github.com/zendframework/zend-form/issues/78
+     */
+    public function testCollectionInputFilterContainsExpectedValidators()
+    {
+        $form = new Form;
+        $form->add([
+            'name' => 'collection',
+            'type' => 'collection',
+            'options' => [
+                'target_element' => [
+                    'type' => InputFilterProviderFieldset::class,
+                    'elements' => [
+                        [
+                            'spec' => [
+                                'name' => 'date',
+                                'type' => 'date'
+                            ],
+                        ],
+                    ],
+                    'options' => ['input_filter_spec' => [
+                        'date' => [
+                            'required' => false,
+                            'validators' => [
+                                ['name' => 'StringLength'],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]);
+        $inputFilter = $form->getInputFilter();
+        $filter = $inputFilter->get('collection')->getInputFilter()->get('date');
+
+        $validators = $filter->getValidatorChain()->getValidators();
+        $this->assertCount(3, $validators);
+        $this->assertValidatorFound(Validator\StringLength::class, $validators);
+        $this->assertValidatorFound(Validator\Date::class, $validators);
+        $this->assertValidatorFound(Validator\Step::class, $validators);
+    }
+}


### PR DESCRIPTION
As reported in #78, if you compose an input filter provider fieldset as a target element of a collection in order to allow providing a default fieldset for the collection, input provider elements composed by the input filter provider fieldset were not being merged correctly into the input filter.

This patch checks to see if the fieldset's input filter represents a collection, and, if so, will check its own composed input filter for the element and merge it if found.