### PR TITLE
resolve #158

### DIFF
--- a/src/Element/Date.php
+++ b/src/Element/Date.php
@@ -16,6 +16,9 @@ use Zend\Validator\DateStep as DateStepValidator;
 
 class Date extends DateTimeElement
 {
+
+    const DATETIME_FORMAT = 'Y-m-d';
+
     /**
      * Seed attributes
      *

--- a/src/Element/DateTime.php
+++ b/src/Element/DateTime.php
@@ -12,6 +12,7 @@ namespace Zend\Form\Element;
 use DateInterval;
 use DateTime as PhpDateTime;
 use Zend\Form\Element;
+use Zend\Form\Exception\InvalidArgumentException;
 use Zend\InputFilter\InputProviderInterface;
 use Zend\Validator\Date as DateValidator;
 use Zend\Validator\DateStep as DateStepValidator;
@@ -120,17 +121,60 @@ class DateTime extends Element implements InputProviderInterface
         $validators = [];
         $validators[] = $this->getDateValidator();
 
-        if (isset($this->attributes['min'])) {
-            $validators[] = new GreaterThanValidator([
-                'min'       => $this->attributes['min'],
-                'inclusive' => true,
-            ]);
+        if (isset($this->attributes['min']) &&
+            \DateTime::createFromFormat(
+                static::DATETIME_FORMAT,
+                $this->attributes['min']
+            ) instanceof \DateTimeInterface
+        ) {
+            $validators[] = new GreaterThanValidator(
+                [
+                    'min' => $this->attributes['min'],
+                    'inclusive' => true,
+                ]
+            );
+        } elseif (isset($this->attributes['min']) &&
+            ! \DateTime::createFromFormat(
+                static::DATETIME_FORMAT,
+                $this->attributes['min']
+            ) instanceof \DateTimeInterface
+        ) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    '%1$s expects "min" to conform to %2$s; received "%3$s"',
+                    __METHOD__,
+                    static::DATETIME_FORMAT,
+                    $this->attributes['min']
+                )
+            );
         }
-        if (isset($this->attributes['max'])) {
-            $validators[] = new LessThanValidator([
-                'max'       => $this->attributes['max'],
+
+        if (isset($this->attributes['max']) &&
+            \DateTime::createFromFormat(
+                static::DATETIME_FORMAT,
+                $this->attributes['max']
+            ) instanceof \DateTimeInterface
+        ) {
+            $validators[] = new LessThanValidator(
+                [
+                'max' => $this->attributes['max'],
                 'inclusive' => true,
-            ]);
+                ]
+            );
+        } elseif (isset($this->attributes['max']) &&
+            ! \DateTime::createFromFormat(
+                static::DATETIME_FORMAT,
+                $this->attributes['max']
+            ) instanceof \DateTimeInterface
+        ) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    '%1$s expects "max" to conform to %2$s; received "%3$s"',
+                    __METHOD__,
+                    static::DATETIME_FORMAT,
+                    $this->attributes['max']
+                )
+            );
         }
         if (! isset($this->attributes['step'])
             || 'any' !== $this->attributes['step']
@@ -145,7 +189,7 @@ class DateTime extends Element implements InputProviderInterface
     /**
      * Retrieves a Date Validator configured for a DateTime Input type
      *
-     * @return DateTime
+     * @return DateValidator
      */
     protected function getDateValidator()
     {
@@ -155,7 +199,7 @@ class DateTime extends Element implements InputProviderInterface
     /**
      * Retrieves a DateStep Validator configured for a DateTime Input type
      *
-     * @return DateTime
+     * @return DateStepValidator
      */
     protected function getStepValidator()
     {

--- a/src/Element/DateTimeLocal.php
+++ b/src/Element/DateTimeLocal.php
@@ -13,7 +13,10 @@ use Zend\Validator\DateStep as DateStepValidator;
 
 class DateTimeLocal extends DateTime
 {
+
     const DATETIME_LOCAL_FORMAT = 'Y-m-d\TH:i';
+
+    const DATETIME_FORMAT = self::DATETIME_LOCAL_FORMAT;
 
     /**
      * Seed attributes

--- a/src/Element/Month.php
+++ b/src/Element/Month.php
@@ -15,6 +15,9 @@ use Zend\Validator\ValidatorInterface;
 
 class Month extends DateTime
 {
+
+    const DATETIME_FORMAT = 'Y-m';
+
     /**
      * Seed attributes
      *

--- a/src/Element/Time.php
+++ b/src/Element/Time.php
@@ -14,6 +14,9 @@ use Zend\Validator\DateStep as DateStepValidator;
 
 class Time extends DateTime
 {
+
+    const DATETIME_FORMAT = 'H:i:s';
+
     /**
      * Seed attributes
      *

--- a/src/Element/Week.php
+++ b/src/Element/Week.php
@@ -11,6 +11,8 @@ namespace Zend\Form\Element;
 
 use Zend\Validator\DateStep as DateStepValidator;
 use Zend\Validator\Regex as RegexValidator;
+use Zend\Validator\GreaterThan as GreaterThanValidator;
+use Zend\Validator\LessThan as LessThanValidator;
 
 class Week extends DateTime
 {
@@ -51,5 +53,37 @@ class Week extends DateTime
             'baseValue' => $baseValue,
             'step'      => new \DateInterval("P{$stepValue}W"),
         ]);
+    }
+
+    /**
+     * @see https://bugs.php.net/bug.php?id=74511
+     * @return array
+     */
+    protected function getValidators()
+    {
+        if ($this->validators) {
+            return $this->validators;
+        }
+        $validators = [];
+        $validators[] = $this->getDateValidator();
+        if (isset($this->attributes['min'])) {
+            $validators[] = new GreaterThanValidator([
+                'min'       => $this->attributes['min'],
+                'inclusive' => true,
+            ]);
+        }
+        if (isset($this->attributes['max'])) {
+            $validators[] = new LessThanValidator([
+                'max'       => $this->attributes['max'],
+                'inclusive' => true,
+            ]);
+        }
+        if (! isset($this->attributes['step'])
+            || 'any' !== $this->attributes['step']
+        ) {
+            $validators[] = $this->getStepValidator();
+        }
+        $this->validators = $validators;
+        return $this->validators;
     }
 }

--- a/test/Element/DateTest.php
+++ b/test/Element/DateTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Form\Element;
 use DateTime;
 use PHPUnit\Framework\TestCase;
 use Zend\Form\Element\Date as DateElement;
+use Zend\Form\Exception\InvalidArgumentException;
 
 /**
  * @covers \Zend\Form\Element\Date
@@ -157,5 +158,34 @@ class DateTest extends TestCase
                     break;
             }
         }
+    }
+
+    public function testFailsWithInvalidMinSpecification()
+    {
+        $element = new DateElement('foo');
+        $element->setAttributes(
+            [
+            'inclusive' => true,
+            'min'       => '2000-01-01T00',
+            'step'      => '1',
+            ]
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $element->getInputSpecification();
+    }
+
+    public function testFailsWithInvalidMaxSpecification()
+    {
+        $element = new DateElement('foo');
+        $element->setAttributes(
+            [
+            'inclusive' => true,
+            'max'       => '2001-01-01T00',
+            'step'      => '1',
+            ]
+        );
+        $this->expectException(InvalidArgumentException::class);
+        $element->getInputSpecification();
     }
 }

--- a/test/Element/DateTimeLocalTest.php
+++ b/test/Element/DateTimeLocalTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Form\Element;
 
 use PHPUnit\Framework\TestCase;
 use Zend\Form\Element\DateTimeLocal as DateTimeLocalElement;
+use Zend\Form\Exception\InvalidArgumentException;
 
 class DateTimeLocalTest extends TestCase
 {
@@ -19,8 +20,8 @@ class DateTimeLocalTest extends TestCase
         $element = new DateTimeLocalElement('foo');
         $element->setAttributes([
             'inclusive' => true,
-            'min'       => '2000-01-01T00:00Z',
-            'max'       => '2001-01-01T00:00Z',
+            'min'       => '2000-01-01T00:00',
+            'max'       => '2001-01-01T00:00',
             'step'      => '1',
         ]);
 
@@ -40,11 +41,11 @@ class DateTimeLocalTest extends TestCase
             switch ($class) {
                 case 'Zend\Validator\GreaterThan':
                     $this->assertTrue($validator->getInclusive());
-                    $this->assertEquals('2000-01-01T00:00Z', $validator->getMin());
+                    $this->assertEquals('2000-01-01T00:00', $validator->getMin());
                     break;
                 case 'Zend\Validator\LessThan':
                     $this->assertTrue($validator->getInclusive());
-                    $this->assertEquals('2001-01-01T00:00Z', $validator->getMax());
+                    $this->assertEquals('2001-01-01T00:00', $validator->getMax());
                     break;
                 case 'Zend\Validator\DateStep':
                     $dateInterval = new \DateInterval('PT1M');
@@ -54,5 +55,34 @@ class DateTimeLocalTest extends TestCase
                     break;
             }
         }
+    }
+
+    public function testFailsWithInvalidMinSpecification()
+    {
+        $element = new DateTimeLocalElement('foo');
+        $element->setAttributes(
+            [
+            'inclusive' => true,
+            'min'       => '2001-01-01T00:00Z',
+            'step'      => '1',
+            ]
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $element->getInputSpecification();
+    }
+
+    public function testFailsWithInvalidMaxSpecification()
+    {
+        $element = new DateTimeLocalElement('foo');
+        $element->setAttributes(
+            [
+            'inclusive' => true,
+            'max'       => '2001-01-01T00:00Z',
+            'step'      => '1',
+            ]
+        );
+        $this->expectException(InvalidArgumentException::class);
+        $element->getInputSpecification();
     }
 }

--- a/test/Element/DateTimeTest.php
+++ b/test/Element/DateTimeTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Form\Element;
 use DateTime;
 use PHPUnit\Framework\TestCase;
 use Zend\Form\Element\DateTime as DateTimeElement;
+use Zend\Form\Exception\InvalidArgumentException;
 
 class DateTimeTest extends TestCase
 {
@@ -118,5 +119,34 @@ class DateTimeTest extends TestCase
         ]);
 
         $this->assertSame($format, $element->getFormat());
+    }
+
+    public function testFailsWithInvalidMinSpecification()
+    {
+        $element = new DateTimeElement('foo');
+        $element->setAttributes(
+            [
+            'inclusive' => true,
+            'min'       => '2000-01-01T00',
+            'step'      => '1',
+            ]
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $element->getInputSpecification();
+    }
+
+    public function testFailsWithInvalidMaxSpecification()
+    {
+        $element = new DateTimeElement('foo');
+        $element->setAttributes(
+            [
+            'inclusive' => true,
+            'max'       => '2001-01-01T00',
+            'step'      => '1',
+            ]
+        );
+        $this->expectException(InvalidArgumentException::class);
+        $element->getInputSpecification();
     }
 }

--- a/test/Element/TimeTest.php
+++ b/test/Element/TimeTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\Form\Element;
 
 use PHPUnit\Framework\TestCase;
 use Zend\Form\Element\Time as TimeElement;
+use Zend\Form\Exception\InvalidArgumentException;
 
 class TimeTest extends TestCase
 {
@@ -57,5 +58,34 @@ class TimeTest extends TestCase
                     break;
             }
         }
+    }
+
+    public function testFailsWithInvalidMinSpecification()
+    {
+        $element = new TimeElement('foo');
+        $element->setAttributes(
+            [
+            'inclusive' => true,
+            'min'       => '00:00',
+            'step'      => '1',
+            ]
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $element->getInputSpecification();
+    }
+
+    public function testFailsWithInvalidMaxSpecification()
+    {
+        $element = new TimeElement('foo');
+        $element->setAttributes(
+            [
+            'inclusive' => true,
+            'max'       => '00:00',
+            'step'      => '1',
+            ]
+        );
+        $this->expectException(InvalidArgumentException::class);
+        $element->getInputSpecification();
     }
 }

--- a/test/Element/WeekTest.php
+++ b/test/Element/WeekTest.php
@@ -59,13 +59,13 @@ class WeekTest extends TestCase
     public function weekValuesDataProvider()
     {
         return [
-                //    value        expected
-                ['2012-W01',  true],
-                ['2012-W52',  true],
-                ['2012-01',   false],
-                ['W12-2012',  false],
-                ['2012-W1',   false],
-                ['12-W01',    false],
+            //    value        expected
+            ['2012-W01',  true],
+            ['2012-W52',  true],
+            ['2012-01',   false],
+            ['W12-2012',  false],
+            ['2012-W1',   false],
+            ['12-W01',    false],
         ];
     }
 


### PR DESCRIPTION
Throws an InvalidArgumentException when one attempts to create a DateTime element with a string for min or max that does not conform to the expected \DateTime format.