### PR TITLE
Fix check for Traversable in ElementFactory

### DIFF
--- a/src/ElementFactory.php
+++ b/src/ElementFactory.php
@@ -9,6 +9,7 @@
 
 namespace Zend\Form;
 
+use Traversable;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\FactoryInterface;


### PR DESCRIPTION
Otherwise, the check for `instanceof Traversable` would always return false. See https://3v4l.org/YgpKg
This affects setCreationOptions on line 121