### PR TITLE
fixed form hydration for forms with wrapped elements

### DIFF
--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -569,8 +569,7 @@ class Fieldset extends Element implements FieldsetInterface
         $hydrator = $this->getHydrator();
         $hydratableData = [];
 
-        foreach ($this->iterator as $element) {
-            $name = $element->getName();
+        foreach ($this->iterator as $name => $element) {
 
             if ($validationGroup
                 && (! array_key_exists($name, $validationGroup) && ! in_array($name, $validationGroup))

--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -570,7 +570,6 @@ class Fieldset extends Element implements FieldsetInterface
         $hydratableData = [];
 
         foreach ($this->iterator as $name => $element) {
-
             if ($validationGroup
                 && (! array_key_exists($name, $validationGroup) && ! in_array($name, $validationGroup))
             ) {

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -798,9 +798,9 @@ class FormTest extends TestCase
         ];
         $this->populateForm();
         $this->form->setHydrator(new Hydrator\ObjectProperty());
-		$this->form->setName('formName');
+        $this->form->setName('formName');
         $this->form->setWrapElements(true);
-		$this->form->prepare();
+        $this->form->prepare();
         $this->form->bind($model);
         $this->form->setData($validSet);
 

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -785,6 +785,39 @@ class FormTest extends TestCase
         ], $model->foobar);
     }
 
+    public function testBindValuesWithWrappingPopulatesBoundObject()
+    {
+        $model = new stdClass;
+        $validSet = [
+            'foo' => 'abcde',
+            'bar' => ' ALWAYS valid ',
+            'foobar' => [
+                'foo' => 'abcde',
+                'bar' => ' always VALID',
+            ],
+        ];
+        $this->populateForm();
+        $this->form->setHydrator(new Hydrator\ObjectProperty());
+		$this->form->setName('formName');
+        $this->form->setWrapElements(true);
+		$this->form->prepare();
+        $this->form->bind($model);
+        $this->form->setData($validSet);
+
+        $this->assertObjectNotHasAttribute('foo', $model);
+        $this->assertObjectNotHasAttribute('bar', $model);
+        $this->assertObjectNotHasAttribute('foobar', $model);
+
+        $this->form->isValid();
+
+        $this->assertEquals($validSet['foo'], $model->foo);
+        $this->assertEquals('always valid', $model->bar);
+        $this->assertEquals([
+            'foo' => 'abcde',
+            'bar' => 'always valid',
+        ], $model->foobar);
+    }
+
     public function testHasFactoryComposedByDefault()
     {
         $factory = $this->form->getFormFactory();


### PR DESCRIPTION
After updating the dependencies on a project which hasn't been updated in a while I stumbled upon a problem with form hydration.

When using a form with `setWrapElements(true);` the method `bindValues` in `FieldSet `fails because it fetches the elements name with `$name = $element->getName();`
This fails cause the name might be something like `myFormName[myFormElement]` instead of `myFormElement` and it is not recognized.

Prior to commit 82b0cdcad2be8313f78bc53eb4d775fc243281cf the method simply used `foreach ($this->iterator as $name => $element) {` which still works.

Please correct me if I'm wrong but I think the current behaviour is wrong.
I've reverted the line and provided an additional unit test.