### PR TITLE
[Docs] Fixes wrong and outdated links to other components

### DIFF
--- a/doc/book/element/captcha.md
+++ b/doc/book/element/captcha.md
@@ -8,7 +8,7 @@ CAPTCHA adapter in use.
 ## Basic Usage
 
 A CAPTCHA adapter must be attached in order for validation to be included in the
-element's input filter specification. See the [zend-captcha documentation](https://zendframework.github.io/zend-captcha/adapters/)
+element's input filter specification. See the [zend-captcha documentation](https://docs.zendframework.com/zend-captcha/adapters/)
 for more information on what adapters are available.
 
 ```php

--- a/doc/book/element/file.md
+++ b/doc/book/element/file.md
@@ -2,7 +2,7 @@
 
 `Zend\Form\Element\File` represents a form file input and
 provides a default input specification with a type of
-[FileInput](http://framework.zend.com/manual/current/en/modules/zend.input-filter.file-input.html)
+[FileInput](https://docs.zendframework.com/zend-inputfilter/file-input/)
 (important for handling validators and filters correctly).
 It is intended for use with the [FormFile](../helper/form-file.md) view helper.
 

--- a/doc/book/element/intro.md
+++ b/doc/book/element/intro.md
@@ -4,7 +4,7 @@ A set of specialized elements are provided for accomplishing application-centric
 tasks. These include several HTML5 input elements with matching server-side
 validators, the `Csrf` element (to prevent Cross Site Request Forgery attacks),
 and the `Captcha` element (to display and validate
-[CAPTCHAs](https://zendframework.github.io/zend-captcha/)).
+[CAPTCHAs](https://docs.zendframework.com/zend-captcha/)).
 
 A `Factory` is provided to facilitate creation of elements, fieldsets, forms,
 and the related input filter. See the [quick start](../quick-start.md#creation-via-factory)

--- a/doc/book/file-upload.md
+++ b/doc/book/file-upload.md
@@ -61,8 +61,8 @@ The `File` element provides several automated features:
 - The form's `enctype` will automatically be set to `multipart/form-data` when
   the form's `prepare()` method is called.
 - The file element's default input specification will create the correct `Input`
-  type: [`Zend\InputFilter\FileInput`](http://framework.zend.com/manual/current/en/modules/zend.input-filter.file-input.html).
-- The `FileInput` will automatically prepend an [UploadFile validator](http://framework.zend.com/manual/current/en/modules/zend.validator.file.html#uploadfile)
+  type: [`Zend\InputFilter\FileInput`](https://docs.zendframework.com/zend-inputfilter/file-input/).
+- The `FileInput` will automatically prepend an [UploadFile validator](https://docs.zendframework.com/zend-validator/validators/file/upload-file/)
   to securely validate that the file is actually an uploaded file, and to report
   any upload errors to the user.
 
@@ -189,7 +189,7 @@ array(1) {
 > }
 > ```
 >
-> [`Zend\InputFilter\FileInput`](http://framework.zend.com/manual/current/en/modules/zend.input-filter.file-input.html) expects the file data be in this
+> [`Zend\InputFilter\FileInput`](https://docs.zendframework.com/zend-inputfilter/file-input/) expects the file data be in this
 > re-mapped array format.
 >
 > Note: [PSR-7](http://www.php-fig.org/psr/psr-7/) also remaps the `$_FILES`
@@ -413,7 +413,7 @@ must use a server-side progress solution.
 
 `Zend\ProgressBar\Upload` provides handlers that can give you the actual state
 of a file upload in progress. To use this feature, you need to choose one of the
-[Upload Progress Handlers](http://framework.zend.com/manual/current/en/modules/zend.progress-bar.upload.html)
+[Upload Progress Handlers](https://docs.zendframework.com/zend-progressbar/upload/)
 (APC, uploadprogress, or Session) and ensure that your server setup has the
 appropriate extension or feature enabled.
 
@@ -672,11 +672,11 @@ Related documentation:
 
 - [Form File Element](element/file.md)
 - [Form File View Helper](helper/form-file.md)
-- [List of File Validators](http://framework.zend.com/manual/current/en/modules/zend.validator.file.html)
+- [List of File Validators](https://docs.zendframework.com/zend-validator/validators/file/intro/)
 - [List of File Filters](http://zendframework.github.io/zend-filter/file/)
 - [File Post-Redirect-Get Controller Plugin](https://docs.zendframework.com/zend-mvc-plugin-fileprg/)
-- [Zend\InputFilter\FileInput](http://framework.zend.com/manual/current/en/modules/zend.input-filter.file-input.html)
-- [Upload Progress Handlers](http://framework.zend.com/manual/current/en/modules/zend.progress-bar.upload.html)
+- [Zend\InputFilter\FileInput](https://docs.zendframework.com/zend-inputfilter/file-input/)
+- [Upload Progress Handlers](https://docs.zendframework.com/zend-progressbar/upload/)
 - [Upload Progress View Helpers](helper/upload-progress-helpers.md)
 
 External resources and blog posts from the community:

--- a/doc/book/file-upload.md
+++ b/doc/book/file-upload.md
@@ -3,7 +3,7 @@
 zend-form provides support for file uploading by using features from each of
 [zend-inputfilter](https://github.com/zendframework/zend-inputfilter),
 [zend-validator](https://github.com/zendframework/zend-validator),
-[zend-filter](https://zendframework.github.io/zend-filter), and
+[zend-filter](https://docs.zendframework.com/zend-filter), and
 [zend-progressbar](https://github.com/zendframework/zend-progressbar). These
 reusable framework components provide a convenient and secure way for handling
 file uploads in your projects.
@@ -208,7 +208,7 @@ One strategy to get around this is to split the form into multiple forms. One
 form for the file upload inputs and another for the other standard inputs.
 
 When you cannot separate the forms, the [File Post-Redirect-Get
-Plugin](https://zendframework.github.io/zend-mvc-plugin-fileprg/) can be used to
+Plugin](https://docs.zendframework.com/zend-mvc-plugin-fileprg/) can be used to
 manage the file inputs and save off valid uploads until the entire form is
 valid.
 
@@ -674,7 +674,7 @@ Related documentation:
 - [Form File View Helper](helper/form-file.md)
 - [List of File Validators](http://framework.zend.com/manual/current/en/modules/zend.validator.file.html)
 - [List of File Filters](http://zendframework.github.io/zend-filter/file/)
-- [File Post-Redirect-Get Controller Plugin](https://zendframework.github.io/zend-mvc-plugin-fileprg/)
+- [File Post-Redirect-Get Controller Plugin](https://docs.zendframework.com/zend-mvc-plugin-fileprg/)
 - [Zend\InputFilter\FileInput](http://framework.zend.com/manual/current/en/modules/zend.input-filter.file-input.html)
 - [Upload Progress Handlers](http://framework.zend.com/manual/current/en/modules/zend.progress-bar.upload.html)
 - [Upload Progress View Helpers](helper/upload-progress-helpers.md)

--- a/doc/book/helper/form-file-apc-progress.md
+++ b/doc/book/helper/form-file-apc-progress.md
@@ -13,7 +13,7 @@ An `id` attribute with a value of `"progress_key"` will automatically be added.
 > The view helper **must** be rendered *before* the file input in the form, or
 > upload progress will not work correctly.
 
-Best used with the [Zend\ProgressBar\Upload\ApcProgress](http://framework.zend.com/manual/current/en/modules/zend.progress-bar.upload.html#apc-progress-handler)
+Best used with the [Zend\ProgressBar\Upload\ApcProgress](https://docs.zendframework.com/zend-progressbar/upload/#apc-progress-handler)
 handler.
 
 See the `apc.rfc1867` ini setting in the [APC Configuration](http://php.net/apc.configuration)

--- a/doc/book/helper/form-file-session-progress.md
+++ b/doc/book/helper/form-file-session-progress.md
@@ -12,7 +12,7 @@ An `id` attribute with a value of `"progress_key"` will automatically be added.
 > The view helper **must** be rendered *before* the file input in the form, or
 > upload progress will not work correctly.
 
-Best used with the [Zend\ProgressBar\Upload\SessionProgress](http://framework.zend.com/manual/current/en/modules/zend.progress-bar.upload.html#session-progress-handler)
+Best used with the [Zend\ProgressBar\Upload\SessionProgress](https://docs.zendframework.com/zend-progressbar/upload/#session-progress-handler)
 handler.
 
 See the [Session Upload Progress](http://php.net/session.upload-progress)

--- a/doc/book/helper/form-file-upload-progress.md
+++ b/doc/book/helper/form-file-upload-progress.md
@@ -12,7 +12,7 @@ An `id` attribute with a value of `progress_key` will automatically be added.
 > The view helper **must** be rendered *before* the file input in the form, or
 > upload progress will not work correctly.
 
-This element should be used with the [Zend\ProgressBar\Upload\UploadProgress](http://framework.zend.com/manual/current/en/modules/zend.progress-bar.upload.html#upload-progress-handler)
+This element should be used with the [Zend\ProgressBar\Upload\UploadProgress](https://docs.zendframework.com/zend-progressbar/upload/#upload-progress-handler)
 handler.
 
 See the [PECL uploadprogress extension](http://pecl.php.net/package/uploadprogress)

--- a/doc/book/helper/intro.md
+++ b/doc/book/helper/intro.md
@@ -3,5 +3,5 @@
 zend-form comes with an initial set of zend-view helper classes for tasks such
 as rendering forms, rendering a text input, rendering a selection box, etc.
 
-See the [view helpers documentation](http://framework.zend.com/manual/current/en/modules/zend.view.helpers.html)
+See the [view helpers documentation](https://docs.zendframework.com/zend-view/helpers/intro/)
 for more information.

--- a/doc/book/intro.md
+++ b/doc/book/intro.md
@@ -12,7 +12,7 @@ The component consists of the following objects:
   elements.
 - Forms, which extend from Fieldsets (and thus Elements). They provide data and
   object binding, and compose [InputFilters](https://github.com/zendframework/zend-inputfilter/).
-  Data binding is done via [zend-hydrator](https://zendframework.github.io/zend-hydrator/).
+  Data binding is done via [zend-hydrator](https://docs.zendframework.com/zend-hydrator/).
 
 To facilitate usage with the view layer, zend-form also aggregates a number of
 form-specific view helpers. These accept elements, fieldsets, and/or forms, and
@@ -21,7 +21,7 @@ use the attributes they compose to render markup.
 A small number of specialized elements are provided for accomplishing
 application-centric tasks.  These include the `Csrf` element, used to prevent
 Cross Site Request Forgery attacks, and the `Captcha` element, used to display
-and validate [CAPTCHAs](https://zendframework.github.io/zend-captcha).
+and validate [CAPTCHAs](https://docs.zendframework.com/zend-captcha).
 
 A `Factory` is provided to facilitate creation of elements, fieldsets, forms,
 and the related input filter. The default `Form` implementation is backed by a

--- a/doc/book/quick-start.md
+++ b/doc/book/quick-start.md
@@ -671,7 +671,7 @@ use Zend\Form\FormInterface;
 $data = $form->getData(FormInterface::VALUES_AS_ARRAY);
 ```
 
-Zend Framework ships several standard [hydrators](https://zendframework.github.io/zend-hydrator/);
+Zend Framework ships several standard [hydrators](https://docs.zendframework.com/zend-hydrator/);
 you can create custom hydrators by implementing `Zend\Hydrator\HydratorInterface`,
 which looks like this:
 


### PR DESCRIPTION
- github.io to docs.zendframework.com
- old manual to new documentation