### PR TITLE
Ensure `form_elements` config is honored in non-zend-mvc contexts

### DIFF
--- a/test/FormElementManagerFactoryTest.php
+++ b/test/FormElementManagerFactoryTest.php
@@ -72,7 +72,7 @@ class FormElementManagerFactoryTest extends TestCase
         $this->assertSame($element, $elements->get('test'));
     }
 
-    public function testConfiguresValidatorServicesWhenFound()
+    public function testConfiguresFormElementsServicesWhenFound()
     {
         $element = $this->prophesize(ElementInterface::class)->reveal();
         $config = [
@@ -105,7 +105,7 @@ class FormElementManagerFactoryTest extends TestCase
         $this->assertSame($element, $elements->get('test-too'));
     }
 
-    public function testDoesNotConfigureValidatorServicesWhenServiceListenerPresent()
+    public function testDoesNotConfigureFormElementsServicesWhenServiceListenerPresent()
     {
         $element = $this->prophesize(ElementInterface::class)->reveal();
         $config = [
@@ -136,7 +136,7 @@ class FormElementManagerFactoryTest extends TestCase
         $this->assertFalse($elements->has('test-too'));
     }
 
-    public function testDoesNotConfigureValidatorServicesWhenConfigServiceNotPresent()
+    public function testDoesNotConfigureFormElementsServicesWhenConfigServiceNotPresent()
     {
         $container = $this->prophesize(ServiceLocatorInterface::class);
         $container->willImplement(ContainerInterface::class);
@@ -151,7 +151,7 @@ class FormElementManagerFactoryTest extends TestCase
         $this->assertInstanceOf(FormElementManager::class, $elements);
     }
 
-    public function testDoesNotConfigureValidatorServicesWhenConfigServiceDoesNotContainValidatorsConfig()
+    public function testDoesNotConfigureFormElementServicesWhenConfigServiceDoesNotContainFormElementsConfig()
     {
         $container = $this->prophesize(ServiceLocatorInterface::class);
         $container->willImplement(ContainerInterface::class);

--- a/test/FormElementManagerFactoryTest.php
+++ b/test/FormElementManagerFactoryTest.php
@@ -10,6 +10,7 @@ namespace ZendTest\Form;
 use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
 use Zend\Form\ElementInterface;
+use Zend\Form\Element\Number;
 use Zend\Form\FormElementManager;
 use Zend\Form\FormElementManagerFactory;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -69,5 +70,101 @@ class FormElementManagerFactoryTest extends TestCase
 
         $elements = $factory->createService($container->reveal());
         $this->assertSame($element, $elements->get('test'));
+    }
+
+    public function testConfiguresValidatorServicesWhenFound()
+    {
+        $element = $this->prophesize(ElementInterface::class)->reveal();
+        $config = [
+            'form_elements' => [
+                'aliases' => [
+                    'test' => Number::class,
+                ],
+                'factories' => [
+                    'test-too' => function ($container) use ($element) {
+                        return $element;
+                    },
+                ],
+            ],
+        ];
+
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn($config);
+
+        $factory = new FormElementManagerFactory();
+        $elements = $factory($container->reveal(), 'FormElementManager');
+
+        $this->assertInstanceOf(FormElementManager::class, $elements);
+        $this->assertTrue($elements->has('test'));
+        $this->assertInstanceOf(Number::class, $elements->get('test'));
+        $this->assertTrue($elements->has('test-too'));
+        $this->assertSame($element, $elements->get('test-too'));
+    }
+
+    public function testDoesNotConfigureValidatorServicesWhenServiceListenerPresent()
+    {
+        $element = $this->prophesize(ElementInterface::class)->reveal();
+        $config = [
+            'form_elements' => [
+                'aliases' => [
+                    'test' => Number::class,
+                ],
+                'factories' => [
+                    'test-too' => function ($container) use ($element) {
+                        return $element;
+                    },
+                ],
+            ],
+        ];
+
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(true);
+        $container->has('config')->shouldNotBeCalled();
+        $container->get('config')->shouldNotBeCalled();
+
+        $factory = new FormElementManagerFactory();
+        $elements = $factory($container->reveal(), 'FormElementManager');
+
+        $this->assertInstanceOf(FormElementManager::class, $elements);
+        $this->assertFalse($elements->has('test'));
+        $this->assertFalse($elements->has('test-too'));
+    }
+
+    public function testDoesNotConfigureValidatorServicesWhenConfigServiceNotPresent()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(false);
+        $container->get('config')->shouldNotBeCalled();
+
+        $factory = new FormElementManagerFactory();
+        $elements = $factory($container->reveal(), 'FormElementManager');
+
+        $this->assertInstanceOf(FormElementManager::class, $elements);
+    }
+
+    public function testDoesNotConfigureValidatorServicesWhenConfigServiceDoesNotContainValidatorsConfig()
+    {
+        $container = $this->prophesize(ServiceLocatorInterface::class);
+        $container->willImplement(ContainerInterface::class);
+
+        $container->has('ServiceListener')->willReturn(false);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn(['foo' => 'bar']);
+        $container->has('MvcTranslator')->willReturn(false); // necessary due to default initializers
+
+        $factory = new FormElementManagerFactory();
+        $elements = $factory($container->reveal(), 'FormElementManager');
+
+        $this->assertInstanceOf(FormElementManager::class, $elements);
+        $this->assertFalse($elements->has('foo'));
     }
 }


### PR DESCRIPTION
Per https://discourse.zendframework.com/t/validatormanager-not-calling-custom-validator-factory/109/5?u=matthew the `form_elements` config key is not honored currently unless the application is within a zend-mvc context. This is due to the fact that `Zend\Form\Module` wires configuration for the `Zend\ModuleManager\Listener\ServiceListener` in order to push merged service configuration into the plugin during bootstrap; no similar logic is available when not in a zend-mvc context, however.

This patch fixes that situation by modifying the `FormElementManagerFactory` to do the following:

- If a `ServiceListener` service exists, it returns the plugin manager immediately (old behavior).
- Otherwise, it checks for the `config` service, and, if found, a `form_elements` key with an array value. When found, it feeds that value to a `Zend\ServiceManager\Config` instance and uses that to configure the plugin manager before returning it.