### PR TITLE
Add PHP 7.2 support, drop HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,17 +59,17 @@ matrix:
     - php: 7.1
       env:
         - DEPS=latest
-    - php: hhvm
+    - php: nightly
       env:
         - DEPS=lowest
-    - php: hhvm
+    - php: nightly
       env:
         - DEPS=locked
-    - php: hhvm
+    - php: nightly
       env:
         - DEPS=latest
   allow_failures:
-    - php: hhvm
+    - php: nightly
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,17 +59,17 @@ matrix:
     - php: 7.1
       env:
         - DEPS=latest
-    - php: nightly
+    - php: 7.2
       env:
         - DEPS=lowest
-    - php: nightly
+    - php: 7.2
       env:
         - DEPS=locked
-    - php: nightly
+    - php: 7.2
       env:
         - DEPS=latest
   allow_failures:
-    - php: nightly
+    - php: 7.2
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,12 @@ language: php
 
 branches:
   except:
-    - /^release-\d+\.\d+\.\d+.*$/
+    - /^release-.*$/
     - /^ghgfk-.*$/
 
 cache:
   directories:
-    - $HOME/.composer/cache
-    - vendor
+    - $HOME/.composer/
     - $HOME/.local
     - zf-mkdoc-theme
 
@@ -80,13 +79,12 @@ install:
   - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
   - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
-  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
+  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update $COMPOSER_ARGS --prefer-lowest --prefer-stable ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - composer show
 
 script:
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; fi
-  - if [[ $TEST_COVERAGE != 'true' ]]; then composer test ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then composer test-coverage ; else composer test ; fi
   - if [[ $CS_CHECK == 'true' ]]; then composer cs-check ; fi
   - if [[ $DEPLOY_DOCS == "true" && "$TRAVIS_TEST_RESULT" == "0" ]]; then wget -O theme-installer.sh "https://raw.githubusercontent.com/zendframework/zf-mkdoc-theme/master/theme-installer.sh" ; chmod 755 theme-installer.sh ; ./theme-installer.sh ; fi
 

--- a/src/Form.php
+++ b/src/Form.php
@@ -328,7 +328,7 @@ class Form extends Fieldset implements FormInterface
      * @param array $values
      * @return mixed
      */
-    public function bindValues(array $values = [])
+    public function bindValues(array $values = [], array $validationGroup = null)
     {
         if (! is_object($this->object)) {
             if ($this->baseFieldset === null || $this->baseFieldset->allowValueBinding() == false) {

--- a/test/View/Helper/FormSelectTest.php
+++ b/test/View/Helper/FormSelectTest.php
@@ -216,7 +216,8 @@ class FormSelectTest extends CommonTestCase
         $element = new SelectElement('foo');
         $element->setValueOptions($options);
         $markup = $this->helper->render($element);
-        list($value, $label) = each($options);
+        $value = key($options);
+        $label = current($options);
         $this->assertRegexp(sprintf('#option .*?value="%s"#', (string) $value), $markup);
     }
 


### PR DESCRIPTION
- [x] Adopt recent `.travis.yml` ZF standards ([zend-session/.travis.yml](https://github.com/zendframework/zend-session/blob/develop/.travis.yml) picked)
- [x] Drop HVVM
- [x] Test PHP 7.2
- [x] Add partial PHP 7.2 support
    1. `Fatal error: Declaration of Zend\Form\Form::bindValues(array $values = Array) must be compatible with Zend\Form\Fieldset::bindValues(array $values = Array, ?array $validationGroup = NULL) in /tmp/zend-form/src/Form.php`
    1. `1) ZendTest\Form\View\Helper\FormSelectTest::testScalarOptionValues with data set #0 (array('string'))
The each() function is deprecated.`