### PR TITLE
Compare against DateTimeInterface in DateTime::getValue

### DIFF
--- a/src/Element/DateTime.php
+++ b/src/Element/DateTime.php
@@ -66,9 +66,9 @@ class DateTime extends Element implements InputProviderInterface
     /**
      * Retrieve the element value
      *
-     * If the value is a DateTime object, and $returnFormattedValue is true
-     * (the default), we return the string
-     * representation using the currently registered format.
+     * If the value is instance of DateTimeInterface, and $returnFormattedValue
+     * is true (the default), we return the string representation using the
+     * currently registered format.
      *
      * If $returnFormattedValue is false, the original value will be
      * returned, regardless of type.
@@ -79,7 +79,7 @@ class DateTime extends Element implements InputProviderInterface
     public function getValue($returnFormattedValue = true)
     {
         $value = parent::getValue();
-        if (! $value instanceof PhpDateTime || ! $returnFormattedValue) {
+        if (! $value instanceof DateTimeInterface || ! $returnFormattedValue) {
             return $value;
         }
         $format = $this->getFormat();


### PR DESCRIPTION
When checking whether [`Element\DateTime`][2]’s value is an actual [PHP `DateTime`][3], it’s more useful to check if it’s an instance of [`DateTimeInterface`][1], since such approach allows to use either [`DateTime`][3] or [`DateTimeImmutable`][4] object as element value.

[1]: https://secure.php.net/manual/en/class.datetimeinterface.php
[2]: https://github.com/zendframework/zend-form/blob/master/src/Element/DateTime.php
[3]: https://secure.php.net/manual/en/class.datetime.php
[4]: https://secure.php.net/manual/en/class.datetimeimmutable.php