### PR TITLE
Single Update to Zend\\Form\\Form::bindValues()

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -324,11 +324,14 @@ class Form extends Fieldset implements FormInterface
 
     /**
      * Bind values to the bound object
+     * Added $validationGroup to method signature to make it align with Fieldset::bindValues()
+     * Otherwise error is seen when using Zend\Form\Form under PHP 7.2
      *
      * @param array $values
+     * @param array $validationGroup
      * @return mixed
      */
-    public function bindValues(array $values = [])
+    public function bindValues(array $values = [], array $validationGroup = null)
     {
         if (! is_object($this->object)) {
             if ($this->baseFieldset === null || $this->baseFieldset->allowValueBinding() == false) {


### PR DESCRIPTION
Updated Zend\\Form\\Form::bindValues() such that the function signature matches that of Zend\\Form\\Fieldset::bindValues(), which avoids error seen when using Zend\\Form\\Form under PHP 7.2.