### PR TITLE
Prevent AbstractHelper from attempting to output malformed user input

### DIFF
--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -247,7 +247,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
             //@TODO Escape event attributes like AbstractHtmlElement view helper does in htmlAttribs ??
             try {
                 $escapedAttribute = $escapeAttr($value);
-                $strings[] = sprintf('%s="%s"', $escape($key), $escapedAttribute );
+                $strings[] = sprintf('%s="%s"', $escape($key), $escapedAttribute);
             }
             catch( \Zend\Escaper\Exception\RuntimeException $x ){
                 $strings[] = sprintf('%s="%s"', $escape($key), '');

--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -248,8 +248,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
             try {
                 $escapedAttribute = $escapeAttr($value);
                 $strings[] = sprintf('%s="%s"', $escape($key), $escapedAttribute);
-            }
-            catch( \Zend\Escaper\Exception\RuntimeException $x ){
+            } catch (\Zend\Escaper\Exception\RuntimeException $x) {
                 $strings[] = sprintf('%s="%s"', $escape($key), '');
             }
         }

--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -245,7 +245,13 @@ abstract class AbstractHelper extends BaseAbstractHelper
             $value = $this->translateHtmlAttributeValue($key, $value);
 
             //@TODO Escape event attributes like AbstractHtmlElement view helper does in htmlAttribs ??
-            $strings[] = sprintf('%s="%s"', $escape($key), $escapeAttr($value));
+            try {
+                $escapedAttribute = $escapeAttr($value);
+                $strings[] = sprintf('%s="%s"', $escape($key), $escapedAttribute );
+            }
+            catch( \Zend\Escaper\Exception\RuntimeException $x ){
+                $strings[] = sprintf('%s="%s"', $escape($key), '');
+            }
         }
 
         return implode(' ', $strings);

--- a/test/View/Helper/AbstractHelperTest.php
+++ b/test/View/Helper/AbstractHelperTest.php
@@ -142,4 +142,13 @@ class AbstractHelperTest extends CommonTestCase
             $this->helper->createAttributesString(['class' => 'Welcome'])
         );
     }
+
+    public function testWillInsulateAgainstBadAttributes()
+    {
+        $this->assertSame(
+            'data-value=""',
+            $this->helper->createAttributesString(['data-value' => "\xc3\x28"])
+        );
+
+    }
 }

--- a/test/View/Helper/AbstractHelperTest.php
+++ b/test/View/Helper/AbstractHelperTest.php
@@ -149,6 +149,5 @@ class AbstractHelperTest extends CommonTestCase
             'data-value=""',
             $this->helper->createAttributesString(['data-value' => "\xc3\x28"])
         );
-
     }
 }


### PR DESCRIPTION
Before this PR, malformed UTF8 submitted to a Zend Form causes the form helper to throw a 500 post-submission.  This PR and its test eliminates these errors, by silently removing attack input during the print cycle.

Test added to demonstrate how a simple invalid 2 octet sequence can cause an exception (which then causes your server to 500).

Note that under current behavior, the helper will still throw the error despite all Filter and Validator implementations.  A full test case that demonstrates this is available here:  https://github.com/Saeven/zendframework-form-failure

A change is necessary to prevent routine penetration tests, or user-land attacks from causing critical exceptions.  Users shouldn't be able to craft malicious input that causes 500s.

Thank you for considering this PR.