### PR TITLE
Allow additions to view helper valid attributes

### DIFF
--- a/src/View/Helper/AbstractHelper.php
+++ b/src/View/Helper/AbstractHelper.php
@@ -162,6 +162,17 @@ abstract class AbstractHelper extends BaseAbstractHelper
     ];
 
     /**
+     * Attribute prefixes valid for all tags
+     *
+     * @var array
+     */
+    protected $validTagAttributePrefixes = [
+        'data-' => true,
+        'aria-' => true,
+        'x-'    => true,
+    ];
+
+    /**
      * Attributes valid for the tag represented by this helper
      *
      * This should be overridden in extending classes
@@ -370,9 +381,7 @@ abstract class AbstractHelper extends BaseAbstractHelper
 
             if (! isset($this->validGlobalAttributes[$attribute])
                 && ! isset($this->validTagAttributes[$attribute])
-                && 'data-' != substr($attribute, 0, 5)
-                && 'aria-' != substr($attribute, 0, 5)
-                && 'x-' != substr($attribute, 0, 2)
+                && ! isset($this->validTagAttributePrefixes[substr($attribute, 0, strpos($attribute, '-') + 1)])
             ) {
                 // Invalid attribute for the current tag
                 unset($attributes[$key]);
@@ -448,6 +457,32 @@ abstract class AbstractHelper extends BaseAbstractHelper
         }
 
         return $value;
+    }
+
+    /**
+     * Adds an HTML attribute to the list of valid attributes
+     *
+     * @param string $attribute
+     *
+     * @return AbstractHelper
+     */
+    public function addValidAttribute($attribute)
+    {
+        $this->validTagAttributes[$attribute] = true;
+        return $this;
+    }
+
+    /**
+     * Adds a prefix to the list of valid attribute prefixes
+     *
+     * @param string $prefix
+     *
+     * @return AbstractHelper
+     */
+    public function addValidAttributePrefix($prefix)
+    {
+        $this->validTagAttributePrefixes[$prefix] = true;
+        return $this;
     }
 
     /**

--- a/test/View/Helper/AbstractHelperTest.php
+++ b/test/View/Helper/AbstractHelperTest.php
@@ -60,6 +60,26 @@ class AbstractHelperTest extends CommonTestCase
         );
     }
 
+    public function testWillIncludeAdditionalAttributes()
+    {
+        $this->helper->addValidAttribute('px-custom');
+
+        $this->assertSame(
+            'px-custom="value"',
+            $this->helper->createAttributesString(['px-custom' => 'value'])
+        );
+    }
+
+    public function testWillIncludeAdditionalAttributesByPrefix()
+    {
+        $this->helper->addValidAttributePrefix('px-');
+
+        $this->assertSame(
+            'px-custom="value"',
+            $this->helper->createAttributesString(['px-custom' => 'value'])
+        );
+    }
+
     public function testWillTranslateAttributeValuesCorrectly()
     {
         $translator = self::getMockBuilder(Translator::class)


### PR DESCRIPTION
Currently, the list of valid attributes on the form view helpers is fixed. This pull request adds the ability to add additional valid attributes to view helpers.

My use case is that certain javascript frameworks use non standard attributes (such as `ng-`, `v-`) when binding on form elements. It would simplify development if `Zend/Form` were able to specify these attributes on form inputs.