### PR TITLE
Documentation of form-collection: explaining $wrap param

### DIFF
--- a/docs/book/helper/form-collection.md
+++ b/docs/book/helper/form-collection.md
@@ -24,7 +24,7 @@ $collection->setAllowAdd(true);
 $collection->setTargetElement([ 'type' => ContactFieldset::class ]);
 
 // In a view script:
-$this->formCollection($collection);
+echo $this->formCollection($collection);
 ```
 
 The above, assuming the fieldset is created correctly, will generate one or more

--- a/docs/book/helper/form-collection.md
+++ b/docs/book/helper/form-collection.md
@@ -31,3 +31,10 @@ The above, assuming the fieldset is created correctly, will generate one or more
 fieldsets with the name `contacts[]`, each containing the elements defined in
 `My\ContactFieldset`. The number of fieldsets created will be based on what data
 was bound to the form.
+
+By default, the collection is wrapped into `<fieldset>` tag. You can overide
+this behavior passing `false` as second parameter of the helper.
+
+```php
+$this->formCollection($collection, false); //not wrapped into a fieldset
+```

--- a/docs/book/helper/form-collection.md
+++ b/docs/book/helper/form-collection.md
@@ -32,7 +32,7 @@ fieldsets with the name `contacts[]`, each containing the elements defined in
 `My\ContactFieldset`. The number of fieldsets created will be based on what data
 was bound to the form.
 
-By default, the collection is wrapped into `<fieldset>` tag. You can overide
+By default, the collection is wrapped into `<fieldset>` tag. You can override
 this behavior passing `false` as second parameter of the helper.
 
 You can also prevent fieldset addition using `setShouldWrap()` method.

--- a/docs/book/helper/form-collection.md
+++ b/docs/book/helper/form-collection.md
@@ -35,6 +35,11 @@ was bound to the form.
 By default, the collection is wrapped into `<fieldset>` tag. You can overide
 this behavior passing `false` as second parameter of the helper.
 
+You can also prevent fieldset addition using `setShouldWrap()` method.
+
 ```php
-$this->formCollection($collection, false); //not wrapped into a fieldset
+// In a view script
+// Both following lines are equivalent:
+echo $this->formCollection($collection, false);
+echo $this->formCollection($collection)->setShouldWrap(false);
 ```


### PR DESCRIPTION
Small add to form-collection.md in order to present the utility of second parameter of that view helper ($wrap).

I’ve also added `echo` in example because invoking the helper does nothing (if not echoed).

Please review my text because I’m not English native.