### PR TITLE
WIP: Proposal: Empty object instantiator

### DIFF
--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -73,6 +73,11 @@ class Fieldset extends Element implements FieldsetInterface
     protected $allowedObjectBindingClass;
 
     /**
+     * @var callable
+     */
+    protected $emptyObjectInstantiator;
+
+    /**
      * @param  null|int|string  $name    Optional name for the element
      * @param  array            $options Optional options for the element
      */
@@ -103,7 +108,19 @@ class Fieldset extends Element implements FieldsetInterface
             $this->setAllowedObjectBindingClass($options['allowed_object_binding_class']);
         }
 
+        if (isset($options['empty_object_instantatior'])) {
+            $this->setEmptyObjectInstantiator($options['empty_object_instantiator']);
+        }
+
         return $this;
+    }
+
+    /**
+     * @param callable $emptyObjectInstantiator
+     */
+    public function setEmptyObjectInstantiator(callable $emptyObjectInstantiator)
+    {
+        $this->emptyObjectInstantiator = $emptyObjectInstantiator;
     }
 
     /**
@@ -552,7 +569,7 @@ class Fieldset extends Element implements FieldsetInterface
      */
     public function allowValueBinding()
     {
-        return is_object($this->object);
+        return is_object($this->object) || $this->emptyObjectInstantiator;
     }
 
     /**
@@ -565,6 +582,11 @@ class Fieldset extends Element implements FieldsetInterface
      */
     public function bindValues(array $values = [], array $validationGroup = null)
     {
+        if (! is_object($this->object) && $this->emptyObjectInstantiator) {
+            $instantiator = $this->emptyObjectInstantiator;
+            $this->object = $instantiator($values, $this);
+        }
+
         $objectData = $this->extract();
         $hydrator = $this->getHydrator();
         $hydratableData = [];

--- a/src/Form.php
+++ b/src/Form.php
@@ -312,8 +312,7 @@ class Form extends Fieldset implements FormInterface
      */
     public function setEmptyObjectInstantiator(callable $emptyObjectInstantiator)
     {
-        if (
-            $this->baseFieldset !== null
+        if ($this->baseFieldset !== null
             && \method_exists($this->baseFieldset, 'setEmptyObjectInstantiator')
         ) {
             $this->baseFieldset->setEmptyObjectInstantiator($emptyObjectInstantiator);
@@ -560,7 +559,9 @@ class Form extends Fieldset implements FormInterface
             ));
         }
 
-        if (($flag !== FormInterface::VALUES_AS_ARRAY) && (is_object($this->object) || $this->emptyObjectInstantiator)) {
+        if (($flag !== FormInterface::VALUES_AS_ARRAY)
+            && (is_object($this->object) || $this->emptyObjectInstantiator)
+        ) {
             if (! is_object($this->object) && $this->emptyObjectInstantiator) {
                 $instantiator = $this->emptyObjectInstantiator;
                 $this->object = $instantiator($this->data, $this);

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -2336,7 +2336,7 @@ class FormTest extends TestCase
         $object = new Entity\SimplePublicProperty();
         $object->foo = ['item 1', 'item 2'];
 
-        $this->form->setEmptyObjectInstantiator(function() use ($object) {
+        $this->form->setEmptyObjectInstantiator(function () use ($object) {
             return $object;
         });
 

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -446,6 +446,20 @@ class FormTest extends TestCase
         $this->assertSame($model, $data);
     }
 
+    public function testGetDataReturnsBoundModelCreatedByInstantiator()
+    {
+        $model = new stdClass;
+        $this->form->setHydrator(new Hydrator\ObjectProperty());
+        $this->populateForm();
+        $this->form->setData([]);
+        $this->form->setEmptyObjectInstantiator(function (array $data) use ($model) {
+            return $model;
+        });
+        $this->form->isValid();
+        $data = $this->form->getData();
+        $this->assertSame($model, $data);
+    }
+
     public function testGetDataCanReturnValuesAsArrayWhenModelIsBound()
     {
         $model = new stdClass;
@@ -2288,6 +2302,43 @@ class FormTest extends TestCase
         $object->foo = ['item 1', 'item 2'];
 
         $this->form->bind($object);
+
+        $this->form->setData([
+            'submit' => 'Confirm',
+            'example' => [
+                //'foo' => [] // $_POST doesn't have this if collection is empty
+            ]
+        ]);
+
+        $this->assertTrue($this->form->isValid());
+        $this->assertEquals([], $this->form->getObject()->foo);
+    }
+
+    public function testShouldHydrateEmptyCollectionWithEmptyObjectInstantiator()
+    {
+        $fieldset = new Fieldset('example');
+        $fieldset->add([
+            'type' => Element\Collection::class,
+            'name' => 'foo',
+            'options' => [
+                'label' => 'InputFilterProviderFieldset',
+                'count' => 1,
+                'target_element' => [
+                    'type' => 'text'
+                ]
+            ],
+        ]);
+
+        $this->form->add($fieldset);
+        $this->form->setBaseFieldset($fieldset);
+        $this->form->setHydrator(new ObjectPropertyHydrator());
+
+        $object = new Entity\SimplePublicProperty();
+        $object->foo = ['item 1', 'item 2'];
+
+        $this->form->setEmptyObjectInstantiator(function() use ($object) {
+            return $object;
+        });
 
         $this->form->setData([
             'submit' => 'Confirm',


### PR DESCRIPTION
This PR is made to allow to create the object binded to a form only when form data are available.

Imagine the situation where you need to create a new User with a value-object like this:

```php
class User
{
    public function __construct(string $username, Role $role)
    {
        $this->username = $username;
        $this->role = $role;
    }
}
``` 

To create the user we need to pass properties in constructor, so we can't create (and bind) it before to have some validated data from the form.

Of course the best way should be to use a data mapper, but this would be a convenient way to resolve this problem.

### Proposal:

Add a callable to create the object only when object is empty and **validated** data are available.

### Usage:

```php
$form = new Form();
$form->setEmptyObjectInstantiator(function(array $data, Fieldset $fieldset) use ($entityManager) {  
    return new User(
        $data['username'],
        $entityManager->find(Role::class, $data['role'])
    );
});
```

### Possible problems with the current implementation

Like for `Form::bind()`, in the `setEmptyObjectInstantiator()` we need to set the value even on the `baseFieldset`. To do this we should add the method in the Fieldset interface, but it would be a BC.
Right now I check whether the method exists with `method_exists()`.

### Todo:
- consider other options/proposals
- add more tests

This is just the first idea on how to implement this feature, proposals and suggestions are welcome.
