### PR TITLE
Test for #83 bindValues not working after prepare

### DIFF
--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -2299,4 +2299,59 @@ class FormTest extends TestCase
         $this->assertTrue($this->form->isValid());
         $this->assertEquals([], $this->form->getObject()->foo);
     }
+
+    /**
+     * Test for https://github.com/zendframework/zend-form/issues/83
+     */
+    public function testCanBindNestedCollectionAfterPrepare()
+    {
+
+        $collection = new Element\Collection('numbers');
+        $collection->setOptions([
+            'count' => 2,
+            'allow_add' => false,
+            'allow_remove' => false,
+            'target_element' => [
+                'type' => 'ZendTest\Form\TestAsset\PhoneFieldset'
+            ]
+        ]);
+
+        $form = new Form();
+        $object = new \ArrayObject();
+        $phone1 = new \ZendTest\Form\TestAsset\Entity\Phone();
+        $phone2 = new \ZendTest\Form\TestAsset\Entity\Phone();
+        $phone1->setNumber('unmodified');
+        $phone2->setNumber('unmodified');
+        $collection->setObject([$phone1, $phone2]);
+
+        $form->setObject($object);
+        $form->add($collection);
+
+        $value = [
+            'numbers' => [
+                [
+                    'id' => '1',
+                    'number' => 'modified',
+                ],
+                [
+                    'id' => '2',
+                    'number' => 'modified',
+                ],
+            ],
+        ];
+
+        $form->prepare();
+
+        $form->bindValues($value);
+
+        $fieldsets = $collection->getFieldsets();
+
+        $fieldsetFoo = $fieldsets[0];
+        $fieldsetBar = $fieldsets[1];
+
+        $this->assertEquals($value['numbers'][0]['number'], $fieldsetFoo->getObject()->getNumber());
+        $this->assertEquals($value['numbers'][1]['number'], $fieldsetBar->getObject()->getNumber());
+
+    }
+
 }

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -2351,7 +2351,5 @@ class FormTest extends TestCase
 
         $this->assertEquals($value['numbers'][0]['number'], $fieldsetFoo->getObject()->getNumber());
         $this->assertEquals($value['numbers'][1]['number'], $fieldsetBar->getObject()->getNumber());
-
     }
-
 }


### PR DESCRIPTION
This is a test for #83.

The test fails against tags/release-2.9.2 but is successful against current master.

This is due to the change in Fieldset.php from:
https://github.com/zendframework/zend-form/blob/2d076100e4c6a779b7676d098192e3d1cf74f34e/src/Fieldset.php#L571
to:
https://github.com/zendframework/zend-form/blob/4419eef6dbe9d276e7e27c6a25f022be74534959/src/Fieldset.php#L572

Notice that the same change is present in populateValues, but the test for it is still missing.

The original problem was that prepare() was changing the $name of the nested form elements and then bindValues() could not match that name with the passed $values. This was a bug in release-2.9.2.

This is fixed in the current branch because the name is retrieved differently, but imho the naming is a bit misleading as $element->getName() is indeed a tempting getter to get the element $name. Hence this test imho is needed to be sure the bug does not slip in again.

This test ensures that #83 is fixed, does not happen again and closes #83.

Notice that testCanProperlyPrepareNestedFieldsets() is passed in release-2.9.2, because it is the binding that fails after the "improper" prepare.