### PR TITLE
Updated Form class, bindValues function to set  to empty array if no …

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -361,7 +361,7 @@ class Form extends Fieldset implements FormInterface
 
         // If there is a base fieldset, only hydrate beginning from the base fieldset
         if ($this->baseFieldset !== null) {
-            $data = isset($data[$this->baseFieldset->getName()]) ? $data[$this->baseFieldset->getName()] : [];
+            $data = array_key_exists($this->baseFieldset->getName(), $data) ? $data[$this->baseFieldset->getName()] : [];
             $this->object = $this->baseFieldset->bindValues($data, $validationGroup[$this->baseFieldset->getName()]);
         } else {
             $this->object = parent::bindValues($data, $validationGroup);

--- a/src/Form.php
+++ b/src/Form.php
@@ -361,7 +361,9 @@ class Form extends Fieldset implements FormInterface
 
         // If there is a base fieldset, only hydrate beginning from the base fieldset
         if ($this->baseFieldset !== null) {
-            $data = array_key_exists($this->baseFieldset->getName(), $data) ? $data[$this->baseFieldset->getName()] : [];
+            $data = array_key_exists($this->baseFieldset->getName(), $data)
+                ? $data[$this->baseFieldset->getName()]
+                : [];
             $this->object = $this->baseFieldset->bindValues($data, $validationGroup[$this->baseFieldset->getName()]);
         } else {
             $this->object = parent::bindValues($data, $validationGroup);

--- a/src/Form.php
+++ b/src/Form.php
@@ -361,7 +361,7 @@ class Form extends Fieldset implements FormInterface
 
         // If there is a base fieldset, only hydrate beginning from the base fieldset
         if ($this->baseFieldset !== null) {
-            $data = $data[$this->baseFieldset->getName()];
+            $data = isset($data[$this->baseFieldset->getName()]) ? $data[$this->baseFieldset->getName()] : [];
             $this->object = $this->baseFieldset->bindValues($data, $validationGroup[$this->baseFieldset->getName()]);
         } else {
             $this->object = parent::bindValues($data, $validationGroup);

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -823,16 +823,9 @@ class FormTest extends TestCase
         $baseFieldset = new Fieldset('base_fieldset');
         $baseFieldset->setUseAsBaseFieldset(true);
 
-        $form = new Form('default_form');
+        $form = new Form();
         $form->add($baseFieldset);
         $form->setHydrator(new ObjectPropertyHydrator());
-
-        $baseFieldsetInputFilter = new InputFilter();
-
-        $formInputFilter = new InputFilter();
-        $formInputFilter->add($baseFieldsetInputFilter, 'base_fieldset');
-
-        $form->setInputFilter($formInputFilter);
 
         $model = new stdClass();
         $form->bind($model);

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -15,11 +15,11 @@ use Zend\Form\Element;
 use Zend\Form\Factory;
 use Zend\Form\Fieldset;
 use Zend\Form\Form;
+use Zend\Hydrator;
 use Zend\Hydrator\ObjectProperty as ObjectPropertyHydrator;
 use Zend\InputFilter\BaseInputFilter;
-use Zend\InputFilter\InputFilter;
 use Zend\InputFilter\Factory as InputFilterFactory;
-use Zend\Hydrator;
+use Zend\InputFilter\InputFilter;
 use ZendTest\Form\TestAsset\Entity;
 use ZendTest\Form\TestAsset\HydratorAwareModel;
 
@@ -816,6 +816,35 @@ class FormTest extends TestCase
             'foo' => 'abcde',
             'bar' => 'always valid',
         ], $model->foobar);
+    }
+
+    public function testFormBaseFieldsetBindValuesWithoutInputs()
+    {
+        $baseFieldset = new Fieldset('base_fieldset');
+        $baseFieldset->setUseAsBaseFieldset(true);
+
+        $form = new Form('default_form');
+        $form->add($baseFieldset);
+        $form->setHydrator(new ObjectPropertyHydrator());
+
+        $baseFieldsetInputFilter = new InputFilter();
+
+        $formInputFilter = new InputFilter();
+        $formInputFilter->add($baseFieldsetInputFilter, 'base_fieldset');
+
+        $form->setInputFilter($formInputFilter);
+
+        $model = new stdClass();
+        $form->bind($model);
+
+        $data = [
+            'submit' => 'save',
+        ];
+        $form->setData($data);
+
+        $form->isValid(); // Calls ->bindValues after validation (line: 817)
+
+        $this->assertObjectNotHasAttribute('submit', $model);
     }
 
     public function testHasFactoryComposedByDefault()


### PR DESCRIPTION
Updated Form class, bindValues function to set  to empty array if no data to pass along for baseFieldset

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?

In detail: https://github.com/zendframework/zend-form/issues/215

In short:

`Form->bindValues($data, ...)` calls `Fieldset->bindValues($data, ...)`. 

Fieldset has the function defined as:

```php
public function bindValues(array $values = [], array $validationGroup = null)
```

The `$data` var was set with the following line:

```php
$data = $data[$this->baseFieldset->getName()];
```

In the case of no defined `Input` elements, this may cause there to be no key with that name and have the `$data` variable be `null`. This then causes a fatal error when `Form->bindValues($data, ...)` calls `Fieldset->bindValues($data, ...)`

---

In respect, I've assumed that no tests need to be modified (they pass btw, though there's 40'ish that don't run because they're for Annotation) as this function was assumed to work with the happy-flow of properly calling the `Fieldset->bindValues()` function. This change just catches a bug but does not modify the intended functionality (I think).