### PR TITLE
Fix rendering select element when value is an object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
+- [#218](https://github.com/zendframework/zend-form/pull/218) ensures object values of select elements can be rendered without error.
+
 - [#216](https://github.com/zendframework/zend-form/pull/216) fixes an issue when performing data binding and a fieldset has no mapped
   input elements, casting `null` values to empty arrays to ensure they can be
   passed to an input filter.

--- a/src/View/Helper/FormSelect.php
+++ b/src/View/Helper/FormSelect.php
@@ -285,7 +285,7 @@ class FormSelect extends AbstractHelper
         }
 
         if (! is_array($value)) {
-            return (array) $value;
+            return [$value];
         }
 
         if (! isset($attributes['multiple']) || ! $attributes['multiple']) {

--- a/test/TestAsset/Identifier.php
+++ b/test/TestAsset/Identifier.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+class Identifier
+{
+    private $id;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->id;
+    }
+}

--- a/test/View/Helper/FormSelectTest.php
+++ b/test/View/Helper/FormSelectTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Form\View\Helper;
 use Zend\Form\Element;
 use Zend\Form\Element\Select as SelectElement;
 use Zend\Form\View\Helper\FormSelect as FormSelectHelper;
+use ZendTest\Form\TestAsset\Identifier;
 
 class FormSelectTest extends CommonTestCase
 {
@@ -413,5 +414,32 @@ class FormSelectTest extends CommonTestCase
 
         $this->expectException('Zend\Form\Exception\DomainException');
         $this->helper->render($element);
+    }
+
+    public function getElementWithObjectIdentifiers()
+    {
+        $element = new SelectElement('foo');
+        $options = [
+            [
+                'label' => 'This is the first label',
+                'value' => new Identifier(42),
+            ],
+            [
+                'label' => 'This is the second label',
+                'value' => new Identifier(43),
+            ],
+        ];
+        $element->setValueOptions($options);
+        return $element;
+    }
+
+    public function testRenderElementWithObjectIdentifiers()
+    {
+        $element = $this->getElementWithObjectIdentifiers();
+        $element->setValue(new Identifier(42));
+
+        $markup = $this->helper->render($element);
+        $this->assertRegexp('#option .*?value="42" selected="selected"#', $markup);
+        $this->assertNotRegexp('#option .*?value="43" selected="selected"#', $markup);
     }
 }


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently. **=> Use a select element with object as values (identifiers). The select element I believe is the only element which exhibits this behavior** 
  - [x] Detail the original, incorrect behavior. **=> The select element works when submitting, but it will not render a selected option as selected.** 
  - [x] Detail the new, expected behavior. **=> Select element works the same as using string values, relying on __toString()**
  - [x] Base your feature on the `master` branch, and submit against that branch. **=> done**
  - [x] Add a regression test that demonstrates the bug, and proves the fix. **=> done**
  - [x] Add a `CHANGELOG.md` entry for the fix. **=> done**

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
