### PR TITLE
Allow usage with zend-hydrator v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit doctrine/annotations zendframework/zend-code"
+        - LEGACY_DEPS="phpunit/phpunit doctrine/annotations zendframework/zend-code zendframework/zend-hydrator"
     - php: 5.6
       env:
         - DEPS=latest
@@ -37,7 +37,7 @@ matrix:
     - php: 7
       env:
         - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit doctrine/annotations zendframework/zend-code"
+        - LEGACY_DEPS="phpunit/phpunit doctrine/annotations zendframework/zend-code zendframework/zend-hydrator"
     - php: 7
       env:
         - DEPS=latest
@@ -47,6 +47,7 @@ matrix:
     - php: 7.1
       env:
         - DEPS=locked
+        - LEGACY_DEPS="zendframework/zend-hydrator"
         - CS_CHECK=true
         - TEST_COVERAGE=true
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
-        - LEGACY_DEPS="phpunit/phpunit doctrine/annotations zendframework/zend-code zendframework/zend-hydrator"
+        - LEGACY_DEPS="phpunit/phpunit doctrine/annotations zendframework/zend-code zendframework/zend-hydrator zendframework/zend-captcha"
     - php: 5.6
       env:
         - DEPS=latest

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "zendframework/zend-inputfilter": "^2.8",
-        "zendframework/zend-hydrator": "^1.1 || ^2.1",
+        "zendframework/zend-hydrator": "^1.1 || ^2.1 || ^3.0",
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
@@ -57,6 +57,9 @@
         ]
     },
     "autoload-dev": {
+        "files": [
+            "test/_autoload.php"
+        ],
         "psr-4": {
             "ZendTest\\Form\\": "test/"
         }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0eaf97f239846bb91c5300bf5d590b4a",
+    "content-hash": "f2fd9fec85b32737b783c7f05dea7d9d",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -88,29 +88,32 @@
         },
         {
             "name": "zendframework/zend-filter",
-            "version": "2.7.2",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-filter.git",
-                "reference": "b8d0ff872f126631bf63a932e33aa2d22d467175"
+                "reference": "7b997dbe79459f1652deccc8786d7407fb66caa9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-filter/zipball/b8d0ff872f126631bf63a932e33aa2d22d467175",
-                "reference": "b8d0ff872f126631bf63a932e33aa2d22d467175",
+                "url": "https://api.github.com/repos/zendframework/zend-filter/zipball/7b997dbe79459f1652deccc8786d7407fb66caa9",
+                "reference": "7b997dbe79459f1652deccc8786d7407fb66caa9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7.7 || ^3.1"
+            },
+            "conflict": {
+                "zendframework/zend-validator": "<2.10.1"
             },
             "require-dev": {
-                "pear/archive_tar": "^1.4",
-                "phpunit/phpunit": "^6.0.10 || ^5.7.17",
+                "pear/archive_tar": "^1.4.3",
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
                 "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-crypt": "^2.6 || ^3.0",
-                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-                "zendframework/zend-uri": "^2.5"
+                "zendframework/zend-crypt": "^3.2.1",
+                "zendframework/zend-servicemanager": "^2.7.8 || ^3.3",
+                "zendframework/zend-uri": "^2.6"
             },
             "suggest": {
                 "zendframework/zend-crypt": "Zend\\Crypt component, for encryption filters",
@@ -121,8 +124,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev",
-                    "dev-develop": "2.8-dev"
+                    "dev-master": "2.8.x-dev",
+                    "dev-develop": "2.9.x-dev"
                 },
                 "zf": {
                     "component": "Zend\\Filter",
@@ -139,53 +142,52 @@
                 "BSD-3-Clause"
             ],
             "description": "provides a set of commonly needed data filters",
-            "homepage": "https://github.com/zendframework/zend-filter",
             "keywords": [
+                "ZendFramework",
                 "filter",
-                "zf2"
+                "zf"
             ],
-            "time": "2017-05-17T20:56:17+00:00"
+            "time": "2018-04-11T16:20:04+00:00"
         },
         {
             "name": "zendframework/zend-hydrator",
-            "version": "2.3.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-hydrator.git",
-                "reference": "de0d6465fbc4b7ca345fddc148834c321c4b361f"
+                "reference": "baa10aaafe92559d2579d3dc8417b7b690f260bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-hydrator/zipball/de0d6465fbc4b7ca345fddc148834c321c4b361f",
-                "reference": "de0d6465fbc4b7ca345fddc148834c321c4b361f",
+                "url": "https://api.github.com/repos/zendframework/zend-hydrator/zipball/baa10aaafe92559d2579d3dc8417b7b690f260bc",
+                "reference": "baa10aaafe92559d2579d3dc8417b7b690f260bc",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
-                "zendframework/zend-stdlib": "^3.0"
+                "php": "^7.2",
+                "zendframework/zend-stdlib": "^3.2.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7.21 || ^6.3",
+                "phpspec/prophecy": "^1.7.5",
+                "phpstan/phpstan": "^0.10.5",
+                "phpunit/phpunit": "^7.5",
                 "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-eventmanager": "^3.0",
-                "zendframework/zend-filter": "^2.6",
-                "zendframework/zend-inputfilter": "^2.6",
-                "zendframework/zend-serializer": "^2.6.1",
-                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
+                "zendframework/zend-eventmanager": "^3.2.1",
+                "zendframework/zend-modulemanager": "^2.8",
+                "zendframework/zend-serializer": "^2.9",
+                "zendframework/zend-servicemanager": "^3.3.2"
             },
             "suggest": {
-                "zendframework/zend-eventmanager": "^2.6.2 || ^3.0, to support aggregate hydrator usage",
-                "zendframework/zend-filter": "^2.6, to support naming strategy hydrator usage",
-                "zendframework/zend-serializer": "^2.6.1, to use the SerializableStrategy",
-                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3, to support hydrator plugin manager usage"
+                "zendframework/zend-eventmanager": "^3.2, to support aggregate hydrator usage",
+                "zendframework/zend-serializer": "^2.9, to use the SerializableStrategy",
+                "zendframework/zend-servicemanager": "^3.3, to support hydrator plugin manager usage"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-release-1.0": "1.0-dev",
-                    "dev-release-1.1": "1.1-dev",
-                    "dev-master": "2.3-dev",
-                    "dev-develop": "2.4-dev"
+                    "dev-release-2.4": "2.4.x-dev",
+                    "dev-master": "3.0.x-dev",
+                    "dev-develop": "3.1.x-dev"
                 },
                 "zf": {
                     "component": "Zend\\Hydrator",
@@ -201,46 +203,44 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-hydrator",
+            "description": "Serialize objects to arrays, and vice versa",
             "keywords": [
+                "ZendFramework",
                 "hydrator",
-                "zf2"
+                "zf"
             ],
-            "time": "2017-10-02T15:01:27+00:00"
+            "time": "2018-12-10T17:48:39+00:00"
         },
         {
             "name": "zendframework/zend-inputfilter",
-            "version": "2.8.0",
+            "version": "2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-inputfilter.git",
-                "reference": "e7edd625f2fcdd72a719a7023114c5f4b4f38488"
+                "reference": "3f02179e014d9ef0faccda2ad6c65d38adc338d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-inputfilter/zipball/e7edd625f2fcdd72a719a7023114c5f4b4f38488",
-                "reference": "e7edd625f2fcdd72a719a7023114c5f4b4f38488",
+                "url": "https://api.github.com/repos/zendframework/zend-inputfilter/zipball/3f02179e014d9ef0faccda2ad6c65d38adc338d8",
+                "reference": "3f02179e014d9ef0faccda2ad6c65d38adc338d8",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0",
                 "zendframework/zend-filter": "^2.6",
+                "zendframework/zend-servicemanager": "^2.7.10 || ^3.3.1",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0",
                 "zendframework/zend-validator": "^2.10.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7.23 || ^6.4.3",
-                "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3"
-            },
-            "suggest": {
-                "zendframework/zend-servicemanager": "To support plugin manager support"
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev",
-                    "dev-develop": "2.9-dev"
+                    "dev-master": "2.8.x-dev",
+                    "dev-develop": "2.9.x-dev"
                 },
                 "zf": {
                     "component": "Zend\\InputFilter",
@@ -262,35 +262,103 @@
                 "inputfilter",
                 "zf"
             ],
-            "time": "2017-12-04T21:24:25+00:00"
+            "time": "2018-05-14T17:38:03+00:00"
         },
         {
-            "name": "zendframework/zend-stdlib",
-            "version": "3.1.0",
+            "name": "zendframework/zend-servicemanager",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/zend-stdlib.git",
-                "reference": "debedcfc373a293f9250cc9aa03cf121428c8e78"
+                "url": "https://github.com/zendframework/zend-servicemanager.git",
+                "reference": "9f35a104b8d4d3b32da5f4a3b6efc0dd62e5af42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/debedcfc373a293f9250cc9aa03cf121428c8e78",
-                "reference": "debedcfc373a293f9250cc9aa03cf121428c8e78",
+                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/9f35a104b8d4d3b32da5f4a3b6efc0dd62e5af42",
+                "reference": "9f35a104b8d4d3b32da5f4a3b6efc0dd62e5af42",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.2",
+                "php": "^5.6 || ^7.0",
+                "psr/container": "^1.0",
+                "zendframework/zend-stdlib": "^3.1"
+            },
+            "provide": {
+                "container-interop/container-interop-implementation": "^1.2",
+                "psr/container-implementation": "^1.0"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "^1.6.5",
+                "ocramius/proxy-manager": "^1.0 || ^2.0",
+                "phpbench/phpbench": "^0.13.0",
+                "phpunit/phpunit": "^5.7.25 || ^6.4.4",
+                "zendframework/zend-coding-standard": "~1.0.0"
+            },
+            "suggest": {
+                "ocramius/proxy-manager": "ProxyManager 1.* to handle lazy initialization of services",
+                "zendframework/zend-stdlib": "zend-stdlib ^2.5 if you wish to use the MergeReplaceKey or MergeRemoveKey features in Config instances"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev",
+                    "dev-develop": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "keywords": [
+                "PSR-11",
+                "ZendFramework",
+                "dependency-injection",
+                "di",
+                "dic",
+                "service-manager",
+                "servicemanager",
+                "zf"
+            ],
+            "time": "2018-01-29T16:48:37+00:00"
+        },
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "66536006722aff9e62d1b331025089b7ec71c065"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/66536006722aff9e62d1b331025089b7ec71c065",
+                "reference": "66536006722aff9e62d1b331025089b7ec71c065",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "^2.6.2"
+                "phpbench/phpbench": "^0.13",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev",
-                    "dev-develop": "3.2-dev"
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
                 }
             },
             "autoload": {
@@ -302,25 +370,26 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-stdlib",
+            "description": "SPL extensions, array utilities, error handlers, and more",
             "keywords": [
+                "ZendFramework",
                 "stdlib",
-                "zf2"
+                "zf"
             ],
-            "time": "2016-09-13T14:38:50+00:00"
+            "time": "2018-08-28T21:34:05+00:00"
         },
         {
             "name": "zendframework/zend-validator",
-            "version": "2.10.1",
+            "version": "2.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-validator.git",
-                "reference": "010084ddbd33299bf51ea6f0e07f8f4e8bd832a8"
+                "reference": "38109ed7d8e46cfa71bccbe7e6ca80cdd035f8c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/010084ddbd33299bf51ea6f0e07f8f4e8bd832a8",
-                "reference": "010084ddbd33299bf51ea6f0e07f8f4e8bd832a8",
+                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/38109ed7d8e46cfa71bccbe7e6ca80cdd035f8c9",
+                "reference": "38109ed7d8e46cfa71bccbe7e6ca80cdd035f8c9",
                 "shasum": ""
             },
             "require": {
@@ -355,8 +424,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.10-dev",
-                    "dev-develop": "2.11-dev"
+                    "dev-master": "2.10.x-dev",
+                    "dev-develop": "2.11.x-dev"
                 },
                 "zf": {
                     "component": "Zend\\Validator",
@@ -378,22 +447,22 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2017-08-22T14:19:23+00:00"
+            "time": "2018-02-01T17:05:33+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/annotations",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "5beebb01b025c94e93686b7a0ed3edae81fe3e7f"
+                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/5beebb01b025c94e93686b7a0ed3edae81fe3e7f",
-                "reference": "5beebb01b025c94e93686b7a0ed3edae81fe3e7f",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
+                "reference": "c7f2050c68a9ab0bdb0f98567ec08d80ea7d24d5",
                 "shasum": ""
             },
             "require": {
@@ -402,12 +471,12 @@
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -448,7 +517,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2017-07-22T10:58:02+00:00"
+            "time": "2017-12-06T07:11:42+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -560,25 +629,28 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
+                "reference": "3e01bdad3e18354c3dce54466b7fbe33a9f9f7f8",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -601,37 +673,33 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2018-06-11T23:09:50+00:00"
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.11",
+            "version": "v9.99.99",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8"
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/5da4d3c796c275c55f057af5a643ae297d96b4d8",
-                "reference": "5da4d3c796c275c55f057af5a643ae297d96b4d8",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2.0"
+                "php": "^7"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*|5.*"
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
             },
             "suggest": {
                 "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
             },
             "type": "library",
-            "autoload": {
-                "files": [
-                    "lib/random.php"
-                ]
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
@@ -646,10 +714,113 @@
             "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
             "keywords": [
                 "csprng",
+                "polyfill",
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-09-27T21:40:39+00:00"
+            "time": "2018-07-02T15:55:56+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -707,16 +878,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.2.0",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "66465776cfc249844bde6d117abff1d22e06c2da"
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da",
-                "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
                 "shasum": ""
             },
             "require": {
@@ -754,7 +925,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-27T17:38:31+00:00"
+            "time": "2017-11-30T07:14:17+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -805,33 +976,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.3",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/comparator": "^1.1|^2.0|^3.0",
                 "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7.x-dev"
+                    "dev-master": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -864,44 +1035,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-11-24T13:59:53+00:00"
+            "time": "2018-08-05T17:53:17+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.8",
+            "version": "5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "^1.3",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "^1.0 || ^2.0"
+                "php": "^7.0",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^2.0.1",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.1.4",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.1"
+                "ext-xdebug": "^2.5.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "5.3.x-dev"
                 }
             },
             "autoload": {
@@ -916,7 +1087,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -927,7 +1098,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-02T07:44:40+00:00"
+            "time": "2018-04-06T15:36:58+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1117,16 +1288,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.25",
+            "version": "6.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4b1c822a68ae6577df38a59eb49b046712ec0f6a"
+                "reference": "0973426fb012359b2f18d3bd1e90ef1172839693"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4b1c822a68ae6577df38a59eb49b046712ec0f6a",
-                "reference": "4b1c822a68ae6577df38a59eb49b046712ec0f6a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0973426fb012359b2f18d3bd1e90ef1172839693",
+                "reference": "0973426fb012359b2f18d3bd1e90ef1172839693",
                 "shasum": ""
             },
             "require": {
@@ -1135,33 +1306,35 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^4.0.4",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "^1.2.4",
-                "sebastian/diff": "^1.4.3",
-                "sebastian/environment": "^1.3.4 || ^2.0",
-                "sebastian/exporter": "~2.0",
-                "sebastian/global-state": "^1.1",
-                "sebastian/object-enumerator": "~2.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "~1.0.3|~2.0",
-                "symfony/yaml": "~2.1|~3.0|~4.0"
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^1.0.9",
+                "phpunit/phpunit-mock-objects": "^5.0.9",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^2.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0.1"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -1169,7 +1342,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.7.x-dev"
+                    "dev-master": "6.5.x-dev"
                 }
             },
             "autoload": {
@@ -1195,33 +1368,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-11-14T14:50:51+00:00"
+            "time": "2018-09-08T15:10:43+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.4",
+            "version": "5.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2 || ^2.0"
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
             },
             "conflict": {
-                "phpunit/phpunit": "<5.4.0"
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.4"
+                "phpunit/phpunit": "^6.5.11"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -1229,7 +1402,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -1244,7 +1417,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -1254,7 +1427,101 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2017-06-30T09:13:00+00:00"
+            "time": "2018-08-09T05:50:03+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23T01:57:42+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1303,30 +1570,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": "^7.0",
+                "sebastian/diff": "^2.0 || ^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "2.1.x-dev"
                 }
             },
             "autoload": {
@@ -1357,38 +1624,38 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2018-02-01T13:46:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.3",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^6.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1415,32 +1682,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2017-08-03T08:09:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1465,34 +1732,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2017-07-01T08:51:00+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -1532,27 +1799,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19T08:54:04+00:00"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1560,7 +1827,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1583,33 +1850,34 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "2.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1629,32 +1897,77 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-02-18T15:18:39+00:00"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "2.0.0",
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1682,7 +1995,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+00:00"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1771,16 +2084,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.9.1",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
+                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
                 "shasum": ""
             },
             "require": {
@@ -1845,78 +2158,60 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-05-22T02:43:20+00:00"
+            "time": "2018-11-07T22:31:41+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v4.0.1",
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "873417cb9949f07be8852d41e3be5ab6f09e1218"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/873417cb9949f07be8852d41e3be5ab6f09e1218",
-                "reference": "873417cb9949f07be8852d41e3be5ab6f09e1218",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2017-12-04T18:34:52+00:00"
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
                 "shasum": ""
             },
             "require": {
@@ -1953,34 +2248,41 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2018-01-29T19:49:41+00:00"
         },
         {
             "name": "zendframework/zend-cache",
-            "version": "2.7.2",
+            "version": "2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-cache.git",
-                "reference": "c98331b96d3b9d9b24cf32d02660602edb34d039"
+                "reference": "4983dff629956490c78b88adcc8ece4711d7d8a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-cache/zipball/c98331b96d3b9d9b24cf32d02660602edb34d039",
-                "reference": "c98331b96d3b9d9b24cf32d02660602edb34d039",
+                "url": "https://api.github.com/repos/zendframework/zend-cache/zipball/4983dff629956490c78b88adcc8ece4711d7d8a3",
+                "reference": "4983dff629956490c78b88adcc8ece4711d7d8a3",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
-                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+                "php": "^5.6 || ^7.0",
+                "psr/cache": "^1.0",
+                "psr/simple-cache": "^1.0",
+                "zendframework/zend-eventmanager": "^2.6.3 || ^3.2",
+                "zendframework/zend-servicemanager": "^2.7.8 || ^3.3",
+                "zendframework/zend-stdlib": "^2.7.7 || ^3.1"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0",
+                "psr/simple-cache-implementation": "1.0"
             },
             "require-dev": {
-                "phpbench/phpbench": "^0.10.0",
-                "phpunit/phpunit": "^4.8",
+                "cache/integration-tests": "^0.16",
+                "phpbench/phpbench": "^0.13",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-serializer": "^2.6",
-                "zendframework/zend-session": "^2.6.2"
+                "zendframework/zend-session": "^2.7.4"
             },
             "suggest": {
                 "ext-apc": "APC or compatible extension, to use the APC storage adapter",
@@ -1989,9 +2291,11 @@
                 "ext-memcache": "Memcache >= 2.0.0 to use the Memcache storage adapter",
                 "ext-memcached": "Memcached >= 1.0.0 to use the Memcached storage adapter",
                 "ext-mongo": "Mongo, to use MongoDb storage adapter",
+                "ext-mongodb": "MongoDB, to use the ExtMongoDb storage adapter",
                 "ext-redis": "Redis, to use Redis storage adapter",
                 "ext-wincache": "WinCache, to use the WinCache storage adapter",
                 "ext-xcache": "XCache, to use the XCache storage adapter",
+                "mongodb/mongodb": "Required for use with the ext-mongodb adapter",
                 "mongofill/mongofill": "Alternative to ext-mongo - a pure PHP implementation designed as a drop in replacement",
                 "zendframework/zend-serializer": "Zend\\Serializer component",
                 "zendframework/zend-session": "Zend\\Session component"
@@ -1999,8 +2303,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev",
-                    "dev-develop": "2.8-dev"
+                    "dev-master": "2.8.x-dev",
+                    "dev-develop": "2.9.x-dev"
                 },
                 "zf": {
                     "component": "Zend\\Cache",
@@ -2008,6 +2312,9 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "autoload/patternPluginManagerPolyfill.php"
+                ],
                 "psr-4": {
                     "Zend\\Cache\\": "src/"
                 }
@@ -2016,39 +2323,41 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "provides a generic way to cache any data",
-            "homepage": "https://github.com/zendframework/zend-cache",
+            "description": "Caching implementation with a variety of storage options, as well as codified caching strategies for callbacks, classes, and output",
             "keywords": [
+                "ZendFramework",
                 "cache",
-                "zf2"
+                "psr-16",
+                "psr-6",
+                "zf"
             ],
-            "time": "2016-12-16T11:35:47+00:00"
+            "time": "2018-05-01T21:58:00+00:00"
         },
         {
             "name": "zendframework/zend-captcha",
-            "version": "2.7.1",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-captcha.git",
-                "reference": "2d56293a5ae3e45e7c8ee7030aa8b305768d8014"
+                "reference": "37e9b6a4f632a9399eecbf2e5e325ad89083f87b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-captcha/zipball/2d56293a5ae3e45e7c8ee7030aa8b305768d8014",
-                "reference": "2d56293a5ae3e45e7c8ee7030aa8b305768d8014",
+                "url": "https://api.github.com/repos/zendframework/zend-captcha/zipball/37e9b6a4f632a9399eecbf2e5e325ad89083f87b",
+                "reference": "37e9b6a4f632a9399eecbf2e5e325ad89083f87b",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0",
-                "zendframework/zend-math": "^2.6 || ^3.0",
-                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+                "zendframework/zend-math": "^2.7 || ^3.0",
+                "zendframework/zend-stdlib": "^2.7.7 || ^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
                 "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-session": "^2.6",
+                "zendframework/zend-session": "^2.8",
                 "zendframework/zend-text": "^2.6",
-                "zendframework/zend-validator": "^2.6",
+                "zendframework/zend-validator": "^2.10.1",
                 "zendframework/zendservice-recaptcha": "^3.0"
             },
             "suggest": {
@@ -2061,8 +2370,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev",
-                    "dev-develop": "2.8-dev"
+                    "dev-master": "2.8.x-dev",
+                    "dev-develop": "2.9.x-dev"
                 }
             },
             "autoload": {
@@ -2074,25 +2383,26 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-captcha",
+            "description": "Generate and validate CAPTCHAs using Figlets, images, ReCaptcha, and more",
             "keywords": [
+                "ZendFramework",
                 "captcha",
-                "zf2"
+                "zf"
             ],
-            "time": "2017-02-23T08:09:44+00:00"
+            "time": "2018-04-24T17:24:10+00:00"
         },
         {
             "name": "zendframework/zend-code",
-            "version": "3.3.0",
+            "version": "3.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-code.git",
-                "reference": "6b1059db5b368db769e4392c6cb6cc139e56640d"
+                "reference": "c21db169075c6ec4b342149f446e7b7b724f95eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/6b1059db5b368db769e4392c6cb6cc139e56640d",
-                "reference": "6b1059db5b368db769e4392c6cb6cc139e56640d",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/c21db169075c6ec4b342149f446e7b7b724f95eb",
+                "reference": "c21db169075c6ec4b342149f446e7b7b724f95eb",
                 "shasum": ""
             },
             "require": {
@@ -2113,8 +2423,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev",
-                    "dev-develop": "3.3-dev"
+                    "dev-master": "3.3.x-dev",
+                    "dev-develop": "3.4.x-dev"
                 }
             },
             "autoload": {
@@ -2132,7 +2442,7 @@
                 "code",
                 "zf2"
             ],
-            "time": "2017-10-20T15:21:32+00:00"
+            "time": "2018-08-13T20:36:59+00:00"
         },
         {
             "name": "zendframework/zend-coding-standard",
@@ -2165,30 +2475,30 @@
         },
         {
             "name": "zendframework/zend-escaper",
-            "version": "2.5.2",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-escaper.git",
-                "reference": "2dcd14b61a72d8b8e27d579c6344e12c26141d4e"
+                "reference": "31d8aafae982f9568287cb4dce987e6aff8fd074"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/2dcd14b61a72d8b8e27d579c6344e12c26141d4e",
-                "reference": "2dcd14b61a72d8b8e27d579c6344e12c26141d4e",
+                "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/31d8aafae982f9568287cb4dce987e6aff8fd074",
+                "reference": "31d8aafae982f9568287cb4dce987e6aff8fd074",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev",
-                    "dev-develop": "2.6-dev"
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
                 }
             },
             "autoload": {
@@ -2200,25 +2510,26 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-escaper",
+            "description": "Securely and safely escape HTML, HTML attributes, JavaScript, CSS, and URLs",
             "keywords": [
+                "ZendFramework",
                 "escaper",
-                "zf2"
+                "zf"
             ],
-            "time": "2016-06-30T19:48:38+00:00"
+            "time": "2018-04-25T15:48:53+00:00"
         },
         {
             "name": "zendframework/zend-eventmanager",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-eventmanager.git",
-                "reference": "9d72db10ceb6e42fb92350c0cb54460da61bd79c"
+                "reference": "a5e2583a211f73604691586b8406ff7296a946dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/9d72db10ceb6e42fb92350c0cb54460da61bd79c",
-                "reference": "9d72db10ceb6e42fb92350c0cb54460da61bd79c",
+                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/a5e2583a211f73604691586b8406ff7296a946dd",
+                "reference": "a5e2583a211f73604691586b8406ff7296a946dd",
                 "shasum": ""
             },
             "require": {
@@ -2227,7 +2538,7 @@
             "require-dev": {
                 "athletic/athletic": "^0.1",
                 "container-interop/container-interop": "^1.1.0",
-                "phpunit/phpunit": "^6.0.7 || ^5.7.14",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-stdlib": "^2.7.3 || ^3.0"
             },
@@ -2259,20 +2570,20 @@
                 "events",
                 "zf2"
             ],
-            "time": "2017-07-11T19:17:22+00:00"
+            "time": "2018-04-25T15:33:34+00:00"
         },
         {
             "name": "zendframework/zend-http",
-            "version": "2.7.0",
+            "version": "2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-http.git",
-                "reference": "78aa510c0ea64bfb2aa234f50c4f232c9531acfa"
+                "reference": "2c8aed3d25522618573194e7cc51351f8cd4a45b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/78aa510c0ea64bfb2aa234f50c4f232c9531acfa",
-                "reference": "78aa510c0ea64bfb2aa234f50c4f232c9531acfa",
+                "url": "https://api.github.com/repos/zendframework/zend-http/zipball/2c8aed3d25522618573194e7cc51351f8cd4a45b",
+                "reference": "2c8aed3d25522618573194e7cc51351f8cd4a45b",
                 "shasum": ""
             },
             "require": {
@@ -2283,15 +2594,18 @@
                 "zendframework/zend-validator": "^2.10.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4.1 || ^5.7.15",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.3",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-config": "^3.1 || ^2.6"
+            },
+            "suggest": {
+                "paragonie/certainty": "For automated management of cacert.pem"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev",
-                    "dev-develop": "2.8-dev"
+                    "dev-master": "2.8.x-dev",
+                    "dev-develop": "2.9.x-dev"
                 }
             },
             "autoload": {
@@ -2303,8 +2617,7 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
-            "homepage": "https://github.com/zendframework/zend-http",
+            "description": "Provides an easy interface for performing Hyper-Text Transfer Protocol (HTTP) requests",
             "keywords": [
                 "ZendFramework",
                 "http",
@@ -2312,28 +2625,28 @@
                 "zend",
                 "zf"
             ],
-            "time": "2017-10-13T12:06:24+00:00"
+            "time": "2018-08-13T18:47:03+00:00"
         },
         {
             "name": "zendframework/zend-i18n",
-            "version": "2.7.4",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-i18n.git",
-                "reference": "d3431e29cc00c2a1c6704e601d4371dbf24f6a31"
+                "reference": "6d69af5a04e1a4de7250043cb1322f077a0cdb7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-i18n/zipball/d3431e29cc00c2a1c6704e601d4371dbf24f6a31",
-                "reference": "d3431e29cc00c2a1c6704e601d4371dbf24f6a31",
+                "url": "https://api.github.com/repos/zendframework/zend-i18n/zipball/6d69af5a04e1a4de7250043cb1322f077a0cdb7f",
+                "reference": "6d69af5a04e1a4de7250043cb1322f077a0cdb7f",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0 || ^5.6",
+                "php": "^5.6 || ^7.0",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
                 "zendframework/zend-cache": "^2.6.1",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-config": "^2.6",
@@ -2357,8 +2670,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev",
-                    "dev-develop": "2.8-dev"
+                    "dev-master": "2.9.x-dev",
+                    "dev-develop": "2.10.x-dev"
                 },
                 "zf": {
                     "component": "Zend\\I18n",
@@ -2374,34 +2687,35 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-i18n",
+            "description": "Provide translations for your application, and filter and validate internationalized values",
             "keywords": [
+                "ZendFramework",
                 "i18n",
-                "zf2"
+                "zf"
             ],
-            "time": "2017-05-17T17:00:12+00:00"
+            "time": "2018-05-16T16:39:13+00:00"
         },
         {
             "name": "zendframework/zend-json",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-json.git",
-                "reference": "f42a1588e75c2a3e338cd94c37906231e616daab"
+                "reference": "4dd940e8e6f32f1d36ea6b0677ea57c540c7c19c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-json/zipball/f42a1588e75c2a3e338cd94c37906231e616daab",
-                "reference": "f42a1588e75c2a3e338cd94c37906231e616daab",
+                "url": "https://api.github.com/repos/zendframework/zend-json/zipball/4dd940e8e6f32f1d36ea6b0677ea57c540c7c19c",
+                "reference": "4dd940e8e6f32f1d36ea6b0677ea57c540c7c19c",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "^2.3",
-                "zendframework/zend-stdlib": "^2.7 || ^3.0"
+                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-stdlib": "^2.7.7 || ^3.1"
             },
             "suggest": {
                 "zendframework/zend-json-server": "For implementing JSON-RPC servers",
@@ -2410,8 +2724,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev",
-                    "dev-develop": "3.1-dev"
+                    "dev-master": "3.1.x-dev",
+                    "dev-develop": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -2424,39 +2738,39 @@
                 "BSD-3-Clause"
             ],
             "description": "provides convenience methods for serializing native PHP to JSON and decoding JSON to native PHP",
-            "homepage": "https://github.com/zendframework/zend-json",
             "keywords": [
+                "ZendFramework",
                 "json",
-                "zf2"
+                "zf"
             ],
-            "time": "2016-04-01T02:34:00+00:00"
+            "time": "2018-01-04T17:51:34+00:00"
         },
         {
             "name": "zendframework/zend-loader",
-            "version": "2.5.1",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-loader.git",
-                "reference": "c5fd2f071bde071f4363def7dea8dec7393e135c"
+                "reference": "78f11749ea340f6ca316bca5958eef80b38f9b6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-loader/zipball/c5fd2f071bde071f4363def7dea8dec7393e135c",
-                "reference": "c5fd2f071bde071f4363def7dea8dec7393e135c",
+                "url": "https://api.github.com/repos/zendframework/zend-loader/zipball/78f11749ea340f6ca316bca5958eef80b38f9b6c",
+                "reference": "78f11749ea340f6ca316bca5958eef80b38f9b6c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.23"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev",
-                    "dev-develop": "2.6-dev"
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
                 }
             },
             "autoload": {
@@ -2468,35 +2782,36 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-loader",
+            "description": "Autoloading and plugin loading strategies",
             "keywords": [
+                "ZendFramework",
                 "loader",
-                "zf2"
+                "zf"
             ],
-            "time": "2015-06-03T14:05:47+00:00"
+            "time": "2018-04-30T15:20:54+00:00"
         },
         {
             "name": "zendframework/zend-math",
-            "version": "3.0.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-math.git",
-                "reference": "fda3b4e6c3bb15c35adc6db38b2eacabaa243e65"
+                "reference": "07e43d87fd5c7edc4f54121b9a4625eb10e4b726"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-math/zipball/fda3b4e6c3bb15c35adc6db38b2eacabaa243e65",
-                "reference": "fda3b4e6c3bb15c35adc6db38b2eacabaa243e65",
+                "url": "https://api.github.com/repos/zendframework/zend-math/zipball/07e43d87fd5c7edc4f54121b9a4625eb10e4b726",
+                "reference": "07e43d87fd5c7edc4f54121b9a4625eb10e4b726",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "paragonie/random_compat": "^2.0.2",
-                "php": "^5.5 || ^7.0"
+                "paragonie/random_compat": "^2.0.11 || 9.99.99",
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
                 "ext-bcmath": "If using the bcmath functionality",
@@ -2505,8 +2820,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev",
-                    "dev-develop": "3.1-dev"
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
                 }
             },
             "autoload": {
@@ -2518,88 +2833,26 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-math",
+            "description": "Create cryptographically secure pseudo-random numbers, and manage big integers",
             "keywords": [
+                "ZendFramework",
                 "math",
-                "zf2"
-            ],
-            "time": "2016-04-28T17:37:42+00:00"
-        },
-        {
-            "name": "zendframework/zend-servicemanager",
-            "version": "3.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-servicemanager.git",
-                "reference": "0fa3d3cf588dde0850fff1efa60d44a7aa3c3ab7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/0fa3d3cf588dde0850fff1efa60d44a7aa3c3ab7",
-                "reference": "0fa3d3cf588dde0850fff1efa60d44a7aa3c3ab7",
-                "shasum": ""
-            },
-            "require": {
-                "container-interop/container-interop": "^1.2",
-                "php": "^5.6 || ^7.0",
-                "psr/container": "^1.0",
-                "zendframework/zend-stdlib": "^3.1"
-            },
-            "provide": {
-                "container-interop/container-interop-implementation": "^1.2",
-                "psr/container-implementation": "^1.0"
-            },
-            "require-dev": {
-                "mikey179/vfsstream": "^1.6",
-                "ocramius/proxy-manager": "^1.0 || ^2.0",
-                "phpbench/phpbench": "^0.10.0",
-                "phpunit/phpunit": "^5.7 || ^6.0.6",
-                "zendframework/zend-coding-standard": "~1.0.0"
-            },
-            "suggest": {
-                "ocramius/proxy-manager": "ProxyManager 1.* to handle lazy initialization of services",
-                "zendframework/zend-stdlib": "zend-stdlib ^2.5 if you wish to use the MergeReplaceKey or MergeRemoveKey features in Config instances"
-            },
-            "bin": [
-                "bin/generate-deps-for-config-factory",
-                "bin/generate-factory-for-class"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev",
-                    "dev-develop": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\ServiceManager\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "homepage": "https://github.com/zendframework/zend-servicemanager",
-            "keywords": [
-                "service-manager",
-                "servicemanager",
                 "zf"
             ],
-            "time": "2017-11-27T18:11:25+00:00"
+            "time": "2018-12-04T15:45:09+00:00"
         },
         {
             "name": "zendframework/zend-session",
-            "version": "2.8.3",
+            "version": "2.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-session.git",
-                "reference": "c14be63df39b0caee784e53cd57c43eb48efefea"
+                "reference": "2cfd90e1a2f6b066b9f908599251d8f64f07021b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-session/zipball/c14be63df39b0caee784e53cd57c43eb48efefea",
-                "reference": "c14be63df39b0caee784e53cd57c43eb48efefea",
+                "url": "https://api.github.com/repos/zendframework/zend-session/zipball/2cfd90e1a2f6b066b9f908599251d8f64f07021b",
+                "reference": "2cfd90e1a2f6b066b9f908599251d8f64f07021b",
                 "shasum": ""
             },
             "require": {
@@ -2607,14 +2860,11 @@
                 "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
-            "conflict": {
-                "phpunit/phpunit": ">=6.5.0"
-            },
             "require-dev": {
                 "container-interop/container-interop": "^1.1",
                 "mongodb/mongodb": "^1.0.1",
                 "php-mock/php-mock-phpunit": "^1.1.2 || ^2.0",
-                "phpunit/phpunit": "^5.7.5 || ^6.0.13",
+                "phpunit/phpunit": "^5.7.5 || >=6.0.13 <6.5.0",
                 "zendframework/zend-cache": "^2.6.1",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-db": "^2.7",
@@ -2656,37 +2906,37 @@
                 "session",
                 "zf"
             ],
-            "time": "2017-12-01T17:35:04+00:00"
+            "time": "2018-02-22T16:33:54+00:00"
         },
         {
             "name": "zendframework/zend-text",
-            "version": "2.6.0",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-text.git",
-                "reference": "07ad9388e4d4f12620ad37b52a5b0e4ee7845f92"
+                "reference": "ca987dd4594f5f9508771fccd82c89bc7fbb39ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-text/zipball/07ad9388e4d4f12620ad37b52a5b0e4ee7845f92",
-                "reference": "07ad9388e4d4f12620ad37b52a5b0e4ee7845f92",
+                "url": "https://api.github.com/repos/zendframework/zend-text/zipball/ca987dd4594f5f9508771fccd82c89bc7fbb39ac",
+                "reference": "ca987dd4594f5f9508771fccd82c89bc7fbb39ac",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
+                "php": "^5.6 || ^7.0",
                 "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-config": "^2.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev",
-                    "dev-develop": "2.7-dev"
+                    "dev-master": "2.7.x-dev",
+                    "dev-develop": "2.8.x-dev"
                 }
             },
             "autoload": {
@@ -2698,41 +2948,42 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-text",
+            "description": "Create FIGlets and text-based tables",
             "keywords": [
+                "ZendFramework",
                 "text",
-                "zf2"
+                "zf"
             ],
-            "time": "2016-02-08T19:03:52+00:00"
+            "time": "2018-04-30T14:55:10+00:00"
         },
         {
             "name": "zendframework/zend-uri",
-            "version": "2.5.2",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-uri.git",
-                "reference": "0bf717a239432b1a1675ae314f7c4acd742749ed"
+                "reference": "3b6463645c6766f78ce537c70cb4fdabee1e725f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-uri/zipball/0bf717a239432b1a1675ae314f7c4acd742749ed",
-                "reference": "0bf717a239432b1a1675ae314f7c4acd742749ed",
+                "url": "https://api.github.com/repos/zendframework/zend-uri/zipball/3b6463645c6766f78ce537c70cb4fdabee1e725f",
+                "reference": "3b6463645c6766f78ce537c70cb4fdabee1e725f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
+                "php": "^5.6 || ^7.0",
                 "zendframework/zend-escaper": "^2.5",
-                "zendframework/zend-validator": "^2.5"
+                "zendframework/zend-validator": "^2.10"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev",
-                    "dev-develop": "2.6-dev"
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
                 }
             },
             "autoload": {
@@ -2744,31 +2995,32 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "a component that aids in manipulating and validating » Uniform Resource Identifiers (URIs)",
-            "homepage": "https://github.com/zendframework/zend-uri",
+            "description": "A component that aids in manipulating and validating » Uniform Resource Identifiers (URIs)",
             "keywords": [
+                "ZendFramework",
                 "uri",
-                "zf2"
+                "zf"
             ],
-            "time": "2016-02-17T22:38:51+00:00"
+            "time": "2018-04-30T13:40:08+00:00"
         },
         {
             "name": "zendframework/zend-view",
-            "version": "2.9.0",
+            "version": "2.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-view.git",
-                "reference": "3b6342c381c4437a03fc81d0064c0bb8924914d3"
+                "reference": "0428d6b2a67c7058451394921c90c5576ac5b373"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-view/zipball/3b6342c381c4437a03fc81d0064c0bb8924914d3",
-                "reference": "3b6342c381c4437a03fc81d0064c0bb8924914d3",
+                "url": "https://api.github.com/repos/zendframework/zend-view/zipball/0428d6b2a67c7058451394921c90c5576ac5b373",
+                "reference": "0428d6b2a67c7058451394921c90c5576ac5b373",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0",
                 "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
+                "zendframework/zend-json": "^2.6.1 || ^3.0",
                 "zendframework/zend-loader": "^2.5",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
@@ -2784,17 +3036,16 @@
                 "zendframework/zend-filter": "^2.6.1",
                 "zendframework/zend-http": "^2.5.4",
                 "zendframework/zend-i18n": "^2.6",
-                "zendframework/zend-json": "^2.6.1",
                 "zendframework/zend-log": "^2.7",
                 "zendframework/zend-modulemanager": "^2.7.1",
-                "zendframework/zend-mvc": "^2.7 || ^3.0",
+                "zendframework/zend-mvc": "^2.7.14 || ^3.0",
                 "zendframework/zend-navigation": "^2.5",
                 "zendframework/zend-paginator": "^2.5",
                 "zendframework/zend-permissions-acl": "^2.6",
                 "zendframework/zend-router": "^3.0.1",
                 "zendframework/zend-serializer": "^2.6.1",
                 "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-                "zendframework/zend-session": "^2.6.2",
+                "zendframework/zend-session": "^2.8.1",
                 "zendframework/zend-uri": "^2.5"
             },
             "suggest": {
@@ -2804,8 +3055,8 @@
                 "zendframework/zend-filter": "Zend\\Filter component",
                 "zendframework/zend-http": "Zend\\Http component",
                 "zendframework/zend-i18n": "Zend\\I18n component",
-                "zendframework/zend-json": "Zend\\Json component",
                 "zendframework/zend-mvc": "Zend\\Mvc component",
+                "zendframework/zend-mvc-plugin-flashmessenger": "zend-mvc-plugin-flashmessenger component, if you want to use the FlashMessenger view helper with zend-mvc versions 3 and up",
                 "zendframework/zend-navigation": "Zend\\Navigation component",
                 "zendframework/zend-paginator": "Zend\\Paginator component",
                 "zendframework/zend-permissions-acl": "Zend\\Permissions\\Acl component",
@@ -2818,8 +3069,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.9-dev",
-                    "dev-develop": "3.0-dev"
+                    "dev-master": "2.11.x-dev",
+                    "dev-develop": "2.12.x-dev"
                 }
             },
             "autoload": {
@@ -2837,20 +3088,20 @@
                 "view",
                 "zf2"
             ],
-            "time": "2017-03-21T15:05:56+00:00"
+            "time": "2018-12-10T16:37:55+00:00"
         },
         {
             "name": "zendframework/zendservice-recaptcha",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/ZendService_ReCaptcha.git",
-                "reference": "6c6877c07c8ac73b187911ea5d264a640b234361"
+                "reference": "8caf28e3ab8c18d75534c0741ccd6949347d20e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/ZendService_ReCaptcha/zipball/6c6877c07c8ac73b187911ea5d264a640b234361",
-                "reference": "6c6877c07c8ac73b187911ea5d264a640b234361",
+                "url": "https://api.github.com/repos/zendframework/ZendService_ReCaptcha/zipball/8caf28e3ab8c18d75534c0741ccd6949347d20e8",
+                "reference": "8caf28e3ab8c18d75534c0741ccd6949347d20e8",
                 "shasum": ""
             },
             "require": {
@@ -2859,7 +3110,7 @@
                 "zendframework/zend-json": "^2.6.1 || ^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.5",
                 "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-config": "^2.0",
                 "zendframework/zend-validator": "^2.8.2"
@@ -2870,8 +3121,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev",
-                    "dev-develop": "3.1-dev"
+                    "dev-master": "3.1.x-dev",
+                    "dev-develop": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -2884,12 +3135,12 @@
                 "BSD-3-Clause"
             ],
             "description": "OOP wrapper for the ReCaptcha web service",
-            "homepage": "http://packages.zendframework.com/",
             "keywords": [
+                "ZendFramework",
                 "recaptcha",
-                "zf2"
+                "zf"
             ],
-            "time": "2017-02-09T21:38:25+00:00"
+            "time": "2018-05-08T17:34:06+00:00"
         }
     ],
     "aliases": [],

--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -539,7 +539,11 @@ class Fieldset extends Element implements FieldsetInterface
             if ($this->object instanceof HydratorAwareInterface) {
                 $this->setHydrator($this->object->getHydrator());
             } else {
-                $this->setHydrator(new Hydrator\ArraySerializable());
+                $this->setHydrator(
+                    class_exists(Hydrator\ArraySerializableHydrator::class)
+                    ? new Hydrator\ArraySerializableHydrator()
+                    : new Hydrator\ArraySerializable()
+                );
             }
         }
         return $this->hydrator;
@@ -598,7 +602,7 @@ class Fieldset extends Element implements FieldsetInterface
             }
         }
 
-        if (! empty($hydratableData)) {
+        if (! empty($hydratableData) && $this->object) {
             $this->object = $hydrator->hydrate($hydratableData, $this->object);
         }
 

--- a/test/Annotation/AnnotationBuilderTest.php
+++ b/test/Annotation/AnnotationBuilderTest.php
@@ -10,16 +10,34 @@
 namespace ZendTest\Form\Annotation;
 
 use PHPUnit\Framework\TestCase;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ClassMethodsHydrator;
+use Zend\Hydrator\ObjectProperty;
+use Zend\Hydrator\ObjectPropertyHydrator;
 use Zend\Form\Annotation;
 use ZendTest\Form\TestAsset;
 
 class AnnotationBuilderTest extends TestCase
 {
+    /** @var string */
+    private $classMethodsHydratorClass;
+
+    /** @var string */
+    private $objectPropertyHydratorClass;
+
     public function setUp()
     {
         if (! getenv('TESTS_ZEND_FORM_ANNOTATION_SUPPORT')) {
             $this->markTestSkipped('Enable TESTS_ZEND_FORM_ANNOTATION_SUPPORT to test annotation parsing');
         }
+
+        $this->classMethodsHydratorClass = class_exists(ClassMethodsHydrator::class)
+            ? ClassMethodsHydrator::class
+            : ClassMethods::class;
+
+        $this->objectPropertyHydratorClass = class_exists(ObjectPropertyHydrator::class)
+            ? ObjectPropertyHydrator::class
+            : ObjectProperty::class;
     }
 
     public function testCanCreateFormFromStandardEntity()
@@ -111,7 +129,7 @@ class AnnotationBuilderTest extends TestCase
         $this->assertSame($email, $test, 'Test is element ' . $test->getName());
 
         $hydrator = $form->getHydrator();
-        $this->assertInstanceOf('Zend\Hydrator\ObjectProperty', $hydrator);
+        $this->assertInstanceOf($this->objectPropertyHydratorClass, $hydrator);
     }
 
     public function testFieldsetOrder()
@@ -292,7 +310,7 @@ class AnnotationBuilderTest extends TestCase
         $form    = $builder->createForm($entity);
 
         $hydrator = $form->getHydrator();
-        $this->assertInstanceOf('Zend\Hydrator\ClassMethods', $hydrator);
+        $this->assertInstanceOf($this->classMethodsHydratorClass, $hydrator);
         $this->assertFalse($hydrator->getUnderscoreSeparatedKeys());
     }
 
@@ -360,7 +378,7 @@ class AnnotationBuilderTest extends TestCase
 
         $this->assertInstanceOf('Zend\Form\Fieldset', $fieldset);
         $this->assertInstanceOf('ZendTest\Form\TestAsset\Annotation\Entity', $fieldset->getObject());
-        $this->assertInstanceOf("Zend\Hydrator\ClassMethods", $fieldset->getHydrator());
+        $this->assertInstanceOf($this->classMethodsHydratorClass, $fieldset->getHydrator());
         $this->assertFalse($fieldset->getHydrator()->getUnderscoreSeparatedKeys());
     }
 
@@ -375,7 +393,7 @@ class AnnotationBuilderTest extends TestCase
 
         $this->assertInstanceOf('Zend\Form\Fieldset', $fieldset);
         $this->assertInstanceOf('ZendTest\Form\TestAsset\Annotation\Entity', $fieldset->getObject());
-        $this->assertInstanceOf("Zend\Hydrator\ClassMethods", $fieldset->getHydrator());
+        $this->assertInstanceOf($this->classMethodsHydratorClass, $fieldset->getHydrator());
         $this->assertFalse($fieldset->getHydrator()->getUnderscoreSeparatedKeys());
     }
 

--- a/test/Element/CollectionTest.php
+++ b/test/Element/CollectionTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form\Element;
@@ -17,8 +15,11 @@ use Zend\Form\Element\Collection;
 use Zend\Form\Fieldset;
 use Zend\Form\Form;
 use Zend\Hydrator\ArraySerializable;
-use Zend\Hydrator\ClassMethods as ClassMethodsHydrator;
-use Zend\Hydrator\ObjectProperty as ObjectPropertyHydrator;
+use Zend\Hydrator\ArraySerializableHydrator;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ClassMethodsHydrator;
+use Zend\Hydrator\ObjectProperty;
+use Zend\Hydrator\ObjectPropertyHydrator;
 use Zend\InputFilter\ArrayInput;
 use ZendTest\Form\TestAsset\AddressFieldset;
 use ZendTest\Form\TestAsset\ArrayModel;
@@ -354,7 +355,11 @@ class CollectionTest extends TestCase
     public function testExtractFromObjectDoesntTouchOriginalObject()
     {
         $form = new \Zend\Form\Form();
-        $form->setHydrator(new \Zend\Hydrator\ClassMethods());
+        $form->setHydrator(
+            class_exists(ClassMethodsHydrator::class)
+            ? new ClassMethodsHydrator()
+            : new ClassMethods()
+        );
         $this->productFieldset->setUseAsBaseFieldset(true);
         $form->add($this->productFieldset);
 
@@ -402,7 +407,11 @@ class CollectionTest extends TestCase
         }
 
         $form = new \Zend\Form\Form();
-        $form->setHydrator(new \Zend\Hydrator\ClassMethods());
+        $form->setHydrator(
+            class_exists(ClassMethodsHydrator::class)
+            ? new ClassMethodsHydrator()
+            : new ClassMethods()
+        );
         $this->productFieldset->setUseAsBaseFieldset(true);
         $form->add($this->productFieldset);
 
@@ -451,7 +460,11 @@ class CollectionTest extends TestCase
         ]);
 
         $form = new \Zend\Form\Form();
-        $form->setHydrator(new \Zend\Hydrator\ClassMethods());
+        $form->setHydrator(
+            class_exists(ClassMethodsHydrator::class)
+            ? new ClassMethodsHydrator()
+            : new ClassMethods()
+        );
         $form->add($this->productFieldset);
 
         $product = new Product();
@@ -492,7 +505,11 @@ class CollectionTest extends TestCase
     public function testAddingCollectionElementAfterBind()
     {
         $form = new Form();
-        $form->setHydrator(new ObjectPropertyHydrator());
+        $form->setHydrator(
+            class_exists(ObjectPropertyHydrator::class)
+            ? new ObjectPropertyHydrator()
+            : new ObjectProperty()
+        );
 
         $phone = new \ZendTest\Form\TestAsset\PhoneFieldset();
 
@@ -531,11 +548,19 @@ class CollectionTest extends TestCase
     public function testDoesNotCreateNewObjectsWhenUsingNestedCollections()
     {
         $addressesFieldset = new AddressFieldset();
-        $addressesFieldset->setHydrator(new ClassMethodsHydrator());
+        $addressesFieldset->setHydrator(
+            class_exists(ClassMethodsHydrator::class)
+            ? new ClassMethodsHydrator()
+            : new ClassMethods()
+        );
         $addressesFieldset->remove('city');
 
         $form = new Form();
-        $form->setHydrator(new ObjectPropertyHydrator());
+        $form->setHydrator(
+            class_exists(ObjectPropertyHydrator::class)
+            ? new ObjectPropertyHydrator()
+            : new ObjectProperty()
+        );
         $form->add([
             'name' => 'addresses',
             'type' => 'Collection',
@@ -575,9 +600,17 @@ class CollectionTest extends TestCase
     public function testDoNotCreateExtraFieldsetOnMultipleBind()
     {
         $form = new \Zend\Form\Form();
-        $this->productFieldset->setHydrator(new \Zend\Hydrator\ClassMethods());
+        $this->productFieldset->setHydrator(
+            class_exists(ClassMethodsHydrator::class)
+            ? new ClassMethodsHydrator()
+            : new ClassMethods()
+        );
         $form->add($this->productFieldset);
-        $form->setHydrator(new \Zend\Hydrator\ObjectProperty());
+        $form->setHydrator(
+            class_exists(ObjectPropertyHydrator::class)
+            ? new ObjectPropertyHydrator()
+            : new ObjectProperty()
+        );
 
         $product = new Product();
         $categories = [
@@ -640,14 +673,14 @@ class CollectionTest extends TestCase
         $mockHydrator->expects($this->exactly(2))
             ->method('extract')
             ->will($this->returnCallback(function ($object) {
-                return $object->field . '_foo';
+                return ['value' => $object->field . '_foo'];
             }));
 
         $collection->setHydrator($mockHydrator);
 
         $expected = [
-            'obj2' => 'fieldOne_foo',
-            'obj3' => 'fieldTwo_foo',
+            'obj2' => ['value' => 'fieldOne_foo'],
+            'obj3' => ['value' => 'fieldTwo_foo'],
         ];
 
         $this->assertEquals($expected, $collection->extract());
@@ -706,7 +739,12 @@ class CollectionTest extends TestCase
 
         $obj1 = new stdClass();
 
-        $targetElement->setHydrator(new ObjectPropertyHydrator())
+        $targetElement
+            ->setHydrator(
+                class_exists(ObjectPropertyHydrator::class)
+                ? new ObjectPropertyHydrator()
+                : new ObjectProperty()
+            )
             ->setObject($obj1);
 
         $obj2 = new stdClass();
@@ -724,15 +762,27 @@ class CollectionTest extends TestCase
     public function testCollectionCanBindObjectAndPopulateAndExtractNestedFieldsets()
     {
         $productFieldset = new \ZendTest\Form\TestAsset\ProductFieldset();
-        $productFieldset->setHydrator(new \Zend\Hydrator\ClassMethods());
+        $productFieldset->setHydrator(
+            class_exists(ClassMethodsHydrator::class)
+            ? new ClassMethodsHydrator()
+            : new ClassMethods()
+        );
 
         $mainFieldset = new Fieldset();
         $mainFieldset->setObject(new stdClass);
-        $mainFieldset->setHydrator(new ObjectPropertyHydrator());
+        $mainFieldset->setHydrator(
+            class_exists(ObjectPropertyHydrator::class)
+            ? new ObjectPropertyHydrator()
+            : new ObjectProperty()
+        );
         $mainFieldset->add($productFieldset);
 
         $form = new Form();
-        $form->setHydrator(new ObjectPropertyHydrator());
+        $form->setHydrator(
+            class_exists(ObjectPropertyHydrator::class)
+            ? new ObjectPropertyHydrator()
+            : new ObjectProperty()
+        );
         $form->add([
             'name' => 'collection',
             'type' => 'Collection',
@@ -854,7 +904,11 @@ class CollectionTest extends TestCase
         $collection = $this->form->get('fieldsets');
 
         // this test is using a hydrator set on the collection
-        $collection->setHydrator(new ArraySerializable());
+        $collection->setHydrator(
+            class_exists(ArraySerializableHydrator::class)
+            ? new ArraySerializableHydrator()
+            : new ArraySerializable()
+        );
 
         $this->prepareForExtractWithCustomTraversable($collection);
 
@@ -872,7 +926,11 @@ class CollectionTest extends TestCase
 
         // this test is using a hydrator set on the target element of the collection
         $targetElement = $collection->getTargetElement();
-        $targetElement->setHydrator(new ArraySerializable());
+        $targetElement->setHydrator(
+            class_exists(ArraySerializableHydrator::class)
+            ? new ArraySerializableHydrator()
+            : new ArraySerializable()
+        );
         $obj1 = new ArrayModel();
         $targetElement->setObject($obj1);
 
@@ -956,11 +1014,19 @@ class CollectionTest extends TestCase
     public function testCanBindObjectMultipleNestedFieldsets()
     {
         $productFieldset = new ProductFieldset();
-        $productFieldset->setHydrator(new ArraySerializable());
+        $productFieldset->setHydrator(
+            class_exists(ArraySerializableHydrator::class)
+            ? new ArraySerializableHydrator()
+            : new ArraySerializable()
+        );
         $productFieldset->setObject(new Product());
 
         $nestedFieldset = new Fieldset('nested');
-        $nestedFieldset->setHydrator(new ObjectPropertyHydrator());
+        $nestedFieldset->setHydrator(
+            class_exists(ObjectPropertyHydrator::class)
+            ? new ObjectPropertyHydrator()
+            : new ObjectProperty()
+        );
         $nestedFieldset->setObject(new stdClass());
         $nestedFieldset->add([
             'name' => 'products',
@@ -973,7 +1039,11 @@ class CollectionTest extends TestCase
 
         $mainFieldset = new Fieldset('main');
         $mainFieldset->setUseAsBaseFieldset(true);
-        $mainFieldset->setHydrator(new ObjectPropertyHydrator());
+        $mainFieldset->setHydrator(
+            class_exists(ObjectPropertyHydrator::class)
+            ? new ObjectPropertyHydrator()
+            : new ObjectProperty()
+        );
         $mainFieldset->setObject(new stdClass());
         $mainFieldset->add([
             'name' => 'nested',
@@ -985,7 +1055,11 @@ class CollectionTest extends TestCase
         ]);
 
         $form = new Form();
-        $form->setHydrator(new ObjectPropertyHydrator());
+        $form->setHydrator(
+            class_exists(ObjectPropertyHydrator::class)
+            ? new ObjectPropertyHydrator()
+            : new ObjectProperty()
+        );
         $form->add($mainFieldset);
 
         $market = new stdClass();
@@ -1031,10 +1105,18 @@ class CollectionTest extends TestCase
     {
         // @see https://github.com/zendframework/zf2/issues/5640
         $addressesFieldeset = new \ZendTest\Form\TestAsset\AddressFieldset();
-        $addressesFieldeset->setHydrator(new \Zend\Hydrator\ClassMethods());
+        $addressesFieldeset->setHydrator(
+            class_exists(ClassMethodsHydrator::class)
+            ? new ClassMethodsHydrator()
+            : new ClassMethods()
+        );
 
         $form = new Form();
-        $form->setHydrator(new ObjectPropertyHydrator());
+        $form->setHydrator(
+            class_exists(ObjectPropertyHydrator::class)
+            ? new ObjectPropertyHydrator()
+            : new ObjectProperty()
+        );
         $form->add([
             'name' => 'addresses',
             'type' => 'Collection',
@@ -1203,11 +1285,19 @@ class CollectionTest extends TestCase
         $mainFieldset = new Fieldset();
         $mainFieldset->add(new Element\Text('test'));
         $mainFieldset->setObject(new \ArrayObject());
-        $mainFieldset->setHydrator(new ObjectPropertyHydrator());
+        $mainFieldset->setHydrator(
+            class_exists(ObjectPropertyHydrator::class)
+            ? new ObjectPropertyHydrator()
+            : new ObjectProperty()
+        );
 
         $form = new Form();
         $form->setObject(new \stdClass());
-        $form->setHydrator(new ObjectPropertyHydrator());
+        $form->setHydrator(
+            class_exists(ObjectPropertyHydrator::class)
+            ? new ObjectPropertyHydrator()
+            : new ObjectProperty()
+        );
         $form->add([
             'name' => 'collection',
             'type' => 'Collection',

--- a/test/FactoryTest.php
+++ b/test/FactoryTest.php
@@ -14,8 +14,12 @@ use Zend\Filter;
 use Zend\Form;
 use Zend\Form\Factory as FormFactory;
 use Zend\Form\FormElementManager;
-use Zend\ServiceManager\ServiceManager;
 use Zend\Hydrator\HydratorPluginManager;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ClassMethodsHydrator;
+use Zend\Hydrator\ObjectProperty;
+use Zend\Hydrator\ObjectPropertyHydrator;
+use Zend\ServiceManager\ServiceManager;
 
 class FactoryTest extends TestCase
 {
@@ -327,54 +331,75 @@ class FactoryTest extends TestCase
 
     public function testCanCreateFormsAndSpecifyHydrator()
     {
+        $hydratorType = class_exists(ObjectPropertyHydrator::class)
+            ? ObjectPropertyHydrator::class
+            : ObjectProperty::class;
+
         $form = $this->factory->createForm([
             'name'     => 'foo',
-            'hydrator' => 'Zend\Hydrator\ObjectProperty',
+            'hydrator' => $hydratorType,
         ]);
         $this->assertInstanceOf('Zend\Form\FormInterface', $form);
         $hydrator = $form->getHydrator();
-        $this->assertInstanceOf('Zend\Hydrator\ObjectProperty', $hydrator);
+        $this->assertInstanceOf($hydratorType, $hydrator);
     }
 
     public function testCanCreateFormsAndSpecifyHydratorManagedByHydratorManager()
     {
+        if (class_exists(ObjectPropertyHydrator::class)) {
+            $hydratorShortName = 'ObjectPropertyHydrator';
+            $hydratorType      = ObjectPropertyHydrator::class;
+        } else {
+            $hydratorShortName = 'ObjectProperty';
+            $hydratorType      = ObjectProperty::class;
+        }
+
         $this->services->setService('HydratorManager', new HydratorPluginManager($this->services));
 
         $form = $this->factory->createForm([
             'name'     => 'foo',
-            'hydrator' => 'ObjectProperty',
+            'hydrator' => $hydratorShortName,
         ]);
         $this->assertInstanceOf('Zend\Form\FormInterface', $form);
         $hydrator = $form->getHydrator();
-        $this->assertInstanceOf('Zend\Hydrator\ObjectProperty', $hydrator);
+        $this->assertInstanceOf($hydratorType, $hydrator);
     }
 
     public function testCanCreateHydratorFromArray()
     {
+        $hydratorType = class_exists(ClassMethodsHydrator::class)
+            ? ClassMethodsHydrator::class
+            : ClassMethods::class;
+
         $form = $this->factory->createForm([
             'name' => 'foo',
             'hydrator' => [
-                'type' => 'Zend\Hydrator\ClassMethods',
+                'type' => $hydratorType,
                 'options' => ['underscoreSeparatedKeys' => false],
             ],
         ]);
 
         $this->assertInstanceOf('Zend\Form\FormInterface', $form);
         $hydrator = $form->getHydrator();
-        $this->assertInstanceOf('Zend\Hydrator\ClassMethods', $hydrator);
+
+        $this->assertInstanceOf($hydratorType, $hydrator);
         $this->assertFalse($hydrator->getUnderscoreSeparatedKeys());
     }
 
     public function testCanCreateHydratorFromConcreteClass()
     {
+        $hydratorType = class_exists(ObjectPropertyHydrator::class)
+            ? ObjectPropertyHydrator::class
+            : ObjectProperty::class;
+
         $form = $this->factory->createForm([
             'name' => 'foo',
-            'hydrator' => new \Zend\Hydrator\ObjectProperty()
+            'hydrator' => new $hydratorType()
         ]);
 
         $this->assertInstanceOf('Zend\Form\FormInterface', $form);
         $hydrator = $form->getHydrator();
-        $this->assertInstanceOf('Zend\Hydrator\ObjectProperty', $hydrator);
+        $this->assertInstanceOf($hydratorType, $hydrator);
     }
 
     public function testCanCreateFormsAndSpecifyFactory()
@@ -526,6 +551,10 @@ class FactoryTest extends TestCase
 
     public function testCanCreateFormWithHydratorAndInputFilterAndElementsAndFieldsets()
     {
+        $hydratorType = class_exists(ObjectPropertyHydrator::class)
+            ? ObjectPropertyHydrator::class
+            : ObjectProperty::class;
+
         $form = $this->factory->createForm([
             'name'       => 'foo',
             'elements' => [
@@ -612,7 +641,7 @@ class FactoryTest extends TestCase
                 ],
             ],
             'input_filter' => 'ZendTest\Form\TestAsset\InputFilter',
-            'hydrator'     => 'Zend\Hydrator\ObjectProperty',
+            'hydrator'     => $hydratorType,
         ]);
         $this->assertInstanceOf('Zend\Form\FormInterface', $form);
 
@@ -680,7 +709,7 @@ class FactoryTest extends TestCase
 
         // hydrator
         $hydrator = $form->getHydrator();
-        $this->assertInstanceOf('Zend\Hydrator\ObjectProperty', $hydrator);
+        $this->assertInstanceOf($hydratorType, $hydrator);
     }
 
     public function testCanCreateFormUsingCreate()
@@ -748,7 +777,11 @@ class FactoryTest extends TestCase
 
     public function testCanPullHydratorThroughServiceManager()
     {
-        $this->services->setInvokableClass('MyHydrator', 'Zend\Hydrator\ObjectProperty');
+        $hydratorType = class_exists(ObjectPropertyHydrator::class)
+            ? ObjectPropertyHydrator::class
+            : ObjectProperty::class;
+
+        $this->services->setInvokableClass('MyHydrator', $hydratorType);
 
         $fieldset = $this->factory->createFieldset([
             'hydrator' => 'MyHydrator',
@@ -762,7 +795,7 @@ class FactoryTest extends TestCase
             ]
         ]);
 
-        $this->assertInstanceOf('Zend\Hydrator\ObjectProperty', $fieldset->getHydrator());
+        $this->assertInstanceOf($hydratorType, $fieldset->getHydrator());
     }
 
     public function testCreatedFieldsetsHaveFactoryAndFormElementManagerInjected()

--- a/test/FieldsetTest.php
+++ b/test/FieldsetTest.php
@@ -496,7 +496,11 @@ class FieldsetTest extends TestCase
         $form->add($disabledInput);
 
         $form->setObject($object);
-        $form->setHydrator(new \Zend\Hydrator\ObjectProperty());
+        $form->setHydrator(
+            class_exists(Hydrator\ObjectPropertyHydrator::class)
+            ? new Hydrator\ObjectPropertyHydrator()
+            : new Hydrator\ObjectProperty()
+        );
         $form->bindValues(['not_disabled' => 'modified', 'disabled' => 'modified']);
 
         $this->assertEquals('modified', $object->not_disabled);
@@ -521,7 +525,11 @@ class FieldsetTest extends TestCase
         $form->add($disabledInput);
 
         $form->setObject($object);
-        $form->setHydrator(new \Zend\Hydrator\ObjectProperty());
+        $form->setHydrator(
+            class_exists(Hydrator\ObjectPropertyHydrator::class)
+            ? new Hydrator\ObjectPropertyHydrator()
+            : new Hydrator\ObjectProperty()
+        );
         $form->bindValues(['not_disabled' => 'modified', 'disabled' => 'modified']);
 
         $this->assertEquals('modified', $object->not_disabled);
@@ -560,7 +568,11 @@ class FieldsetTest extends TestCase
     {
         $form = new Form();
         $form->add(new Element('foo'));
-        $form->setHydrator(new Hydrator\ObjectProperty);
+        $form->setHydrator(
+            class_exists(Hydrator\ObjectPropertyHydrator::class)
+            ? new Hydrator\ObjectPropertyHydrator()
+            : new Hydrator\ObjectProperty()
+        );
 
         $object      = new \stdClass();
         $object->foo = 'Initial value';

--- a/test/FormAbstractServiceFactoryTest.php
+++ b/test/FormAbstractServiceFactoryTest.php
@@ -16,12 +16,18 @@ use Zend\Form\FormElementManager;
 use Zend\InputFilter\InputFilterPluginManager;
 use Zend\ServiceManager\ServiceManager;
 use Zend\Hydrator\HydratorPluginManager;
+use Zend\Hydrator\ObjectProperty;
+use Zend\Hydrator\ObjectPropertyHydrator;
 use Zend\Validator\ValidatorPluginManager;
 
 class FormAbstractServiceFactoryTest extends TestCase
 {
     public function setUp()
     {
+        $this->objectPropertyHydratorClass = class_exists(ObjectPropertyHydrator::class)
+            ? ObjectPropertyHydrator::class
+            : ObjectProperty::class;
+
         $services     = $this->services = new ServiceManager;
         $elements     = new FormElementManager($services);
         $filters      = new FilterPluginManager($services);
@@ -116,7 +122,9 @@ class FormAbstractServiceFactoryTest extends TestCase
     public function testFormCanBeCreatedViaInteractionOfAllManagers()
     {
         $formConfig = [
-            'hydrator' => 'ObjectProperty',
+            'hydrator' => class_exists(ObjectPropertyHydrator::class)
+                ? 'ObjectPropertyHydrator'
+                : 'ObjectProperty',
             'type'     => 'Zend\Form\Form',
             'elements' => [
                 [
@@ -137,7 +145,7 @@ class FormAbstractServiceFactoryTest extends TestCase
         $this->assertInstanceOf('Zend\Form\Form', $form);
 
         $hydrator = $form->getHydrator();
-        $this->assertInstanceOf('Zend\Hydrator\ObjectProperty', $hydrator);
+        $this->assertInstanceOf($this->objectPropertyHydratorClass, $hydrator);
 
         $inputFilter = $form->getInputFilter();
         $this->assertInstanceOf('Zend\InputFilter\InputFilter', $inputFilter);
@@ -153,7 +161,9 @@ class FormAbstractServiceFactoryTest extends TestCase
     public function testFormCanBeCreatedViaInteractionOfAllManagersExceptInputFilterManager()
     {
         $formConfig = [
-            'hydrator' => 'ObjectProperty',
+            'hydrator' => class_exists(ObjectPropertyHydrator::class)
+                ? 'ObjectPropertyHydrator'
+                : 'ObjectProperty',
             'type'     => 'Zend\Form\Form',
             'elements' => [
                 [
@@ -188,7 +198,7 @@ class FormAbstractServiceFactoryTest extends TestCase
         $this->assertInstanceOf('Zend\Form\Form', $form);
 
         $hydrator = $form->getHydrator();
-        $this->assertInstanceOf('Zend\Hydrator\ObjectProperty', $hydrator);
+        $this->assertInstanceOf($this->objectPropertyHydratorClass, $hydrator);
 
         $inputFilter = $form->getInputFilter();
         $this->assertInstanceOf('Zend\InputFilter\InputFilter', $inputFilter);

--- a/test/FormTest.php
+++ b/test/FormTest.php
@@ -15,8 +15,12 @@ use Zend\Form\Element;
 use Zend\Form\Factory;
 use Zend\Form\Fieldset;
 use Zend\Form\Form;
-use Zend\Hydrator;
-use Zend\Hydrator\ObjectProperty as ObjectPropertyHydrator;
+use Zend\Hydrator\ArraySerializable;
+use Zend\Hydrator\ArraySerializableHydrator;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ClassMethodsHydrator;
+use Zend\Hydrator\ObjectProperty;
+use Zend\Hydrator\ObjectPropertyHydrator;
 use Zend\InputFilter\BaseInputFilter;
 use Zend\InputFilter\Factory as InputFilterFactory;
 use Zend\InputFilter\InputFilter;
@@ -30,8 +34,32 @@ class FormTest extends TestCase
      */
     protected $form;
 
+    /**
+     * @var string
+     */
+    private $arraySerializableHydratorClass;
+
+    /**
+     * @var string
+     */
+    private $classMethodsHydratorClass;
+
+    /**
+     * @var string
+     */
+    private $objectPropertyHydratorClass;
+
     public function setUp()
     {
+        $this->arraySerializableHydratorClass = class_exists(ArraySerializableHydrator::class)
+            ? ArraySerializableHydrator::class
+            : ArraySerializable::class;
+        $this->classMethodsHydratorClass = class_exists(ClassMethodsHydrator::class)
+            ? ClassMethodsHydrator::class
+            : ClassMethods::class;
+        $this->objectPropertyHydratorClass = class_exists(ObjectPropertyHydrator::class)
+            ? ObjectPropertyHydrator::class
+            : ObjectProperty::class;
         $this->form = new Form();
     }
 
@@ -437,7 +465,7 @@ class FormTest extends TestCase
     public function testGetDataReturnsBoundModel()
     {
         $model = new stdClass;
-        $this->form->setHydrator(new Hydrator\ObjectProperty());
+        $this->form->setHydrator(new $this->objectPropertyHydratorClass());
         $this->populateForm();
         $this->form->setData([]);
         $this->form->bind($model);
@@ -458,7 +486,7 @@ class FormTest extends TestCase
             ],
         ];
         $this->populateForm();
-        $this->form->setHydrator(new Hydrator\ObjectProperty());
+        $this->form->setHydrator(new $this->objectPropertyHydratorClass());
         $this->form->bind($model);
         $this->form->setData($validSet);
         $this->form->isValid();
@@ -478,7 +506,7 @@ class FormTest extends TestCase
             ],
         ];
         $this->populateForm();
-        $this->form->setHydrator(new Hydrator\ObjectProperty());
+        $this->form->setHydrator(new $this->objectPropertyHydratorClass());
         $this->form->bind($model);
         $this->form->setData($validSet);
         $this->form->isValid();
@@ -506,7 +534,7 @@ class FormTest extends TestCase
             ],
         ];
         $this->populateForm();
-        $this->form->setHydrator(new Hydrator\ObjectProperty());
+        $this->form->setHydrator(new $this->objectPropertyHydratorClass());
         $this->form->bind($model, Form::VALUES_RAW);
         $this->form->setData($validSet);
         $this->form->isValid();
@@ -555,7 +583,7 @@ class FormTest extends TestCase
             ],
         ];
         $this->populateForm();
-        $this->form->setHydrator(new Hydrator\ObjectProperty());
+        $this->form->setHydrator(new $this->objectPropertyHydratorClass());
         $this->form->bind($model);
         $this->form->setData($validSet);
         $this->form->setValidationGroup('foo');
@@ -589,7 +617,7 @@ class FormTest extends TestCase
                 ]
             ]
         ]);
-        $this->form->setHydrator(new Hydrator\ObjectProperty());
+        $this->form->setHydrator(new $this->objectPropertyHydratorClass());
         $this->form->bind($model);
         $this->form->setData($data);
         $this->form->setValidationGroup([
@@ -625,7 +653,7 @@ class FormTest extends TestCase
                 ]
             ]
         ]);
-        $this->form->setHydrator(new Hydrator\ObjectProperty());
+        $this->form->setHydrator(new $this->objectPropertyHydratorClass());
         $this->form->bind($model);
         $this->form->setData($dataWithoutCollection);
         $this->form->setValidationGroup(['foo']);
@@ -649,7 +677,7 @@ class FormTest extends TestCase
             ],
         ];
         $this->populateForm();
-        $this->form->setHydrator(new Hydrator\ArraySerializable());
+        $this->form->setHydrator(new $this->arraySerializableHydratorClass());
         $this->form->bind($model);
         $this->form->setData($validSet);
         $this->form->isValid();
@@ -700,7 +728,7 @@ class FormTest extends TestCase
         $object = new stdClass();
         $object->foo = 'foobar';
         $object->bar = 'barbaz';
-        $this->form->setHydrator(new Hydrator\ObjectProperty());
+        $this->form->setHydrator(new $this->objectPropertyHydratorClass());
         $this->form->bind($object);
 
         $foo = $this->form->get('foo');
@@ -719,7 +747,7 @@ class FormTest extends TestCase
             'foo' => 'foos',
             'bar' => 'bar',
         ];
-        $this->form->setHydrator(new Hydrator\ObjectProperty());
+        $this->form->setHydrator(new $this->objectPropertyHydratorClass());
         $this->form->bind($object);
 
         $this->assertTrue($this->form->isValid());
@@ -762,7 +790,7 @@ class FormTest extends TestCase
             ],
         ];
         $this->populateForm();
-        $this->form->setHydrator(new Hydrator\ObjectProperty());
+        $this->form->setHydrator(new $this->objectPropertyHydratorClass());
         $this->form->setBindOnValidate(false);
         $this->form->bind($model);
         $this->form->setData($validSet);
@@ -797,7 +825,7 @@ class FormTest extends TestCase
             ],
         ];
         $this->populateForm();
-        $this->form->setHydrator(new Hydrator\ObjectProperty());
+        $this->form->setHydrator(new $this->objectPropertyHydratorClass());
         $this->form->setName('formName');
         $this->form->setWrapElements(true);
         $this->form->prepare();
@@ -825,7 +853,7 @@ class FormTest extends TestCase
 
         $form = new Form();
         $form->add($baseFieldset);
-        $form->setHydrator(new ObjectPropertyHydrator());
+        $form->setHydrator(new $this->objectPropertyHydratorClass());
 
         $model = new stdClass();
         $form->bind($model);
@@ -1264,7 +1292,7 @@ class FormTest extends TestCase
             ],
         ];
         $this->populateForm();
-        $this->form->setHydrator(new Hydrator\ObjectProperty());
+        $this->form->setHydrator(new $this->objectPropertyHydratorClass());
         $this->form->bind($model);
         $this->form->setData($validSet);
         $this->form->isValid();
@@ -1444,7 +1472,7 @@ class FormTest extends TestCase
     {
         $this->populateHydratorStrategyForm();
 
-        $hydrator = new Hydrator\ObjectProperty();
+        $hydrator = new $this->objectPropertyHydratorClass();
         $hydrator->addStrategy('entities', new TestAsset\HydratorStrategy());
         $this->form->setHydrator($hydrator);
 
@@ -1464,7 +1492,7 @@ class FormTest extends TestCase
         $data = $this->form->getData(Form::VALUES_AS_ARRAY);
         $this->assertEquals($validSet, $data);
 
-        $entities = $model->getEntities();
+        $entities = (array) $model->getEntities();
         $this->assertCount(2, $entities);
 
         $this->assertEquals(111, $entities[0]->getField1());
@@ -1496,10 +1524,10 @@ class FormTest extends TestCase
         $fieldset->add(new Element('foo'));
         $fieldset->setUseAsBaseFieldset(true);
         $this->form->add($fieldset);
-        $this->form->setHydrator(new Hydrator\ArraySerializable());
+        $this->form->setHydrator(new $this->arraySerializableHydratorClass());
 
         $baseHydrator = $this->form->get('foobar')->getHydrator();
-        $this->assertInstanceOf('Zend\Hydrator\ArraySerializable', $baseHydrator);
+        $this->assertInstanceOf($this->arraySerializableHydratorClass, $baseHydrator);
     }
 
     public function testBindWithWrongFlagRaisesException()
@@ -1559,11 +1587,11 @@ class FormTest extends TestCase
 
         // Add a hydrator that ignores if values does not exist in the
         $fieldset->setObject(new Entity\SimplePublicProperty());
-        $fieldset->setHydrator(new \Zend\Hydrator\ObjectProperty());
+        $fieldset->setHydrator(new $this->objectPropertyHydratorClass());
 
         $this->form->add($fieldset);
         $this->form->setBaseFieldset($fieldset);
-        $this->form->setHydrator(new \Zend\Hydrator\ObjectProperty());
+        $this->form->setHydrator(new $this->objectPropertyHydratorClass());
 
         // Add some inputs that do not belong to the base fieldset
         $this->form->add([
@@ -1598,7 +1626,7 @@ class FormTest extends TestCase
         ];
 
         $element = new TestAsset\ElementWithStringToArrayFilter('foo');
-        $hydrator = $this->createMock('Zend\Hydrator\ArraySerializable');
+        $hydrator = $this->createMock($this->arraySerializableHydratorClass);
         $hydrator->expects($this->any())->method('hydrate')->with($filteredData, $this->anything());
 
         $this->form->add($element);
@@ -2280,7 +2308,7 @@ class FormTest extends TestCase
     public function testGetInputFilterInjectsFormInputFilterFactoryInstanceWhenObjectIsInputFilterAware()
     {
         $this->form->setBaseFieldset(new Fieldset());
-        $this->form->setHydrator(new Hydrator\ClassMethods());
+        $this->form->setHydrator(new $this->classMethodsHydratorClass());
         $this->form->bind(new TestAsset\Entity\Cat());
         $inputFilterFactory = $this->form->getFormFactory()->getInputFilterFactory();
         $inputFilter = $this->form->getInputFilter();
@@ -2304,7 +2332,7 @@ class FormTest extends TestCase
 
         $this->form->add($fieldset);
         $this->form->setBaseFieldset($fieldset);
-        $this->form->setHydrator(new ObjectPropertyHydrator());
+        $this->form->setHydrator(new $this->objectPropertyHydratorClass());
 
         $object = new Entity\SimplePublicProperty();
         $object->foo = ['item 1', 'item 2'];

--- a/test/TestAsset/AddressFieldset.php
+++ b/test/TestAsset/AddressFieldset.php
@@ -1,25 +1,29 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form\TestAsset;
 
 use Zend\Form\Fieldset;
 use Zend\InputFilter\InputFilterProviderInterface;
-use Zend\Hydrator\ClassMethods as ClassMethodsHydrator;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ClassMethodsHydrator;
 
 class AddressFieldset extends Fieldset implements InputFilterProviderInterface
 {
     public function __construct()
     {
         parent::__construct('address');
-        $this->setHydrator(new ClassMethodsHydrator(false))
-             ->setObject(new Entity\Address());
+        $this
+            ->setHydrator(
+                class_exists(ClassMethodsHydrator::class)
+                ? new ClassMethodsHydrator(false)
+                : new ClassMethods(false)
+            )
+            ->setObject(new Entity\Address());
 
         $street = new \Zend\Form\Element('street', ['label' => 'Street']);
         $street->setAttribute('type', 'text');

--- a/test/TestAsset/Annotation/ComplexEntityHydratorV2.php
+++ b/test/TestAsset/Annotation/ComplexEntityHydratorV2.php
@@ -16,7 +16,7 @@ use Zend\Form\Annotation;
  * @Annotation\Attributes({"legend":"Register"})
  * @Annotation\Hydrator("Zend\Hydrator\ObjectProperty")
  */
-class ComplexEntity
+class ComplexEntityHydratorV2
 {
     /**
      * @Annotation\ErrorMessage("Invalid or missing username")

--- a/test/TestAsset/Annotation/ComplexEntityHydratorV3.php
+++ b/test/TestAsset/Annotation/ComplexEntityHydratorV3.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset\Annotation;
+
+use Zend\Form\Annotation;
+
+/**
+ * @Annotation\Name("user")
+ * @Annotation\Attributes({"legend":"Register"})
+ * @Annotation\Hydrator("Zend\Hydrator\ObjectPropertyHydrator")
+ */
+class ComplexEntityHydratorV3
+{
+    /**
+     * @Annotation\ErrorMessage("Invalid or missing username")
+     * @Annotation\Filter({"name":"StringTrim"})
+     * @Annotation\Validator({"name":"NotEmpty"})
+     * @Annotation\Validator({"name":"StringLength","options":{"min":3,"max":25}})
+     */
+    public $username;
+
+    /**
+     * @Annotation\Attributes({"type":"password","label":"Enter your password"})
+     * @Annotation\Filter({"name":"StringTrim"})
+     * @Annotation\Validator({"name":"StringLength","options":{"min":3}})
+     */
+    public $password;
+
+    /**
+     * @Annotation\Flags({"priority":100})
+     * @Annotation\Filter({"name":"StringTrim"})
+     * @Annotation\Validator({"name":"EmailAddress","options":{"allow":15}})
+     * @Annotation\Attributes({"type":"email","label":"What is the best email to reach you at?"})
+     */
+    public $email;
+
+    /**
+     * @Annotation\Name("user_image")
+     * @Annotation\AllowEmpty()
+     * @Annotation\Required(false)
+     * @Annotation\Attributes({"type":"text","label":"Provide a URL for your avatar (optional):"})
+     * @Annotation\Validator({"name":"ZendTest\Form\TestAsset\Annotation\UrlValidator"})
+     */
+    public $avatar;
+
+    /**
+     * @Annotation\Exclude()
+     */
+    protected $someComposedObject;
+}

--- a/test/TestAsset/Annotation/EntityUsingInstancePropertyHydratorV2.php
+++ b/test/TestAsset/Annotation/EntityUsingInstancePropertyHydratorV2.php
@@ -12,12 +12,12 @@ namespace ZendTest\Form\TestAsset\Annotation;
 use Zend\Form\Annotation;
 
 /**
- * @Annotation\Options({"use_as_base_fieldset":true})
- */
-class EntityUsingObjectProperty
+* @Annotation\Options({"use_as_base_fieldset":true})
+*/
+class EntityUsingInstancePropertyHydratorV2
 {
     /**
-     * @Annotation\Object("ZendTest\Form\TestAsset\Annotation\Entity")
+     * @Annotation\Instance("ZendTest\Form\TestAsset\Annotation\Entity")
      * @Annotation\Type("Zend\Form\Fieldset")
      * @Annotation\Hydrator({"type":"Zend\Hydrator\ClassMethods", "options": {"underscoreSeparatedKeys": false}})
      */

--- a/test/TestAsset/Annotation/EntityUsingInstancePropertyHydratorV3.php
+++ b/test/TestAsset/Annotation/EntityUsingInstancePropertyHydratorV3.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-hydrator for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-hydrator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset\Annotation;
+
+use Zend\Form\Annotation;
+
+// @codingStandardsIgnoreStart
+/**
+ * @Annotation\Options({"use_as_base_fieldset":true})
+ */
+class EntityUsingInstancePropertyHydratorV3
+{
+    /**
+     * @Annotation\Instance("ZendTest\Form\TestAsset\Annotation\Entity")
+     * @Annotation\Type("Zend\Form\Fieldset")
+     * @Annotation\Hydrator({"type":"Zend\Hydrator\ClassMethodsHydrator", "options": {"underscoreSeparatedKeys": false}})
+     */
+    public $object;
+}
+// @codingStandardsIgnoreEnd

--- a/test/TestAsset/Annotation/EntityUsingObjectPropertyHydratorV2.php
+++ b/test/TestAsset/Annotation/EntityUsingObjectPropertyHydratorV2.php
@@ -12,12 +12,12 @@ namespace ZendTest\Form\TestAsset\Annotation;
 use Zend\Form\Annotation;
 
 /**
-* @Annotation\Options({"use_as_base_fieldset":true})
-*/
-class EntityUsingInstanceProperty
+ * @Annotation\Options({"use_as_base_fieldset":true})
+ */
+class EntityUsingObjectPropertyHydratorV2
 {
     /**
-     * @Annotation\Instance("ZendTest\Form\TestAsset\Annotation\Entity")
+     * @Annotation\Object("ZendTest\Form\TestAsset\Annotation\Entity")
      * @Annotation\Type("Zend\Form\Fieldset")
      * @Annotation\Hydrator({"type":"Zend\Hydrator\ClassMethods", "options": {"underscoreSeparatedKeys": false}})
      */

--- a/test/TestAsset/Annotation/EntityUsingObjectPropertyHydratorV3.php
+++ b/test/TestAsset/Annotation/EntityUsingObjectPropertyHydratorV3.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset\Annotation;
+
+use Zend\Form\Annotation;
+
+// @codingStandardsIgnoreStart
+/**
+ * @Annotation\Options({"use_as_base_fieldset":true})
+ */
+class EntityUsingObjectPropertyHydratorV3
+{
+    /**
+     * @Annotation\Object("ZendTest\Form\TestAsset\Annotation\Entity")
+     * @Annotation\Type("Zend\Form\Fieldset")
+     * @Annotation\Hydrator({"type":"Zend\Hydrator\ClassMethodsHydrator", "options": {"underscoreSeparatedKeys": false}})
+     */
+    public $object;
+}
+// @codingStandardsIgnoreEnd

--- a/test/TestAsset/Annotation/EntityWithHydratorArrayHydratorV2.php
+++ b/test/TestAsset/Annotation/EntityWithHydratorArrayHydratorV2.php
@@ -16,7 +16,7 @@ use Zend\Form\Annotation;
  * @Annotation\Attributes({"legend":"Register"})
  * @Annotation\Hydrator({"type":"Zend\Hydrator\ClassMethods", "options": {"underscoreSeparatedKeys": false}})
  */
-class EntityWithHydratorArray
+class EntityWithHydratorArrayHydratorV2
 {
     /**
      * @Annotation\Options({"label":"Username:", "label_attributes": {"class": "label"}})

--- a/test/TestAsset/Annotation/EntityWithHydratorArrayHydratorV3.php
+++ b/test/TestAsset/Annotation/EntityWithHydratorArrayHydratorV3.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset\Annotation;
+
+use Zend\Form\Annotation;
+
+/**
+ * @Annotation\Name("user")
+ * @Annotation\Attributes({"legend":"Register"})
+ * @Annotation\Hydrator({"type":"Zend\Hydrator\ClassMethodsHydrator", "options": {"underscoreSeparatedKeys": false}})
+ */
+class EntityWithHydratorArrayHydratorV3
+{
+    /**
+     * @Annotation\Options({"label":"Username:", "label_attributes": {"class": "label"}})
+     */
+    public $username;
+}

--- a/test/TestAsset/CategoryFieldset.php
+++ b/test/TestAsset/CategoryFieldset.php
@@ -1,26 +1,30 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form\TestAsset;
 
-use ZendTest\Form\TestAsset\Entity\Category;
 use Zend\Form\Fieldset;
 use Zend\InputFilter\InputFilterProviderInterface;
-use Zend\Hydrator\ClassMethods as ClassMethodsHydrator;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ClassMethodsHydrator;
+use ZendTest\Form\TestAsset\Entity\Category;
 
 class CategoryFieldset extends Fieldset implements InputFilterProviderInterface
 {
     public function __construct()
     {
         parent::__construct('category');
-        $this->setHydrator(new ClassMethodsHydrator())
-             ->setObject(new Category());
+        $this
+            ->setHydrator(
+                class_exists(ClassMethodsHydrator::class)
+                ? new ClassMethodsHydrator()
+                : new ClassMethods()
+            )
+            ->setObject(new Category());
 
         $this->add([
             'name' => 'name',

--- a/test/TestAsset/CityFieldset.php
+++ b/test/TestAsset/CityFieldset.php
@@ -1,25 +1,29 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form\TestAsset;
 
 use Zend\Form\Fieldset;
 use Zend\InputFilter\InputFilterProviderInterface;
-use Zend\Hydrator\ClassMethods as ClassMethodsHydrator;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ClassMethodsHydrator;
 
 class CityFieldset extends Fieldset implements InputFilterProviderInterface
 {
     public function __construct()
     {
         parent::__construct('city');
-        $this->setHydrator(new ClassMethodsHydrator(false))
-             ->setObject(new Entity\City());
+        $this
+            ->setHydrator(
+                class_exists(ClassMethodsHydrator::class)
+                ? new ClassMethodsHydrator(false)
+                : new ClassMethods(false)
+            )
+            ->setObject(new Entity\City());
 
         $name = new \Zend\Form\Element('name', ['label' => 'Name of the city']);
         $name->setAttribute('type', 'text');

--- a/test/TestAsset/CountryFieldset.php
+++ b/test/TestAsset/CountryFieldset.php
@@ -1,25 +1,29 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form\TestAsset;
 
 use Zend\Form\Fieldset;
 use Zend\InputFilter\InputFilterProviderInterface;
-use Zend\Hydrator\ClassMethods as ClassMethodsHydrator;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ClassMethodsHydrator;
 
 class CountryFieldset extends Fieldset implements InputFilterProviderInterface
 {
     public function __construct()
     {
         parent::__construct('country');
-        $this->setHydrator(new ClassMethodsHydrator())
-             ->setObject(new Entity\Country());
+        $this
+            ->setHydrator(
+                class_exists(ClassMethodsHydrator::class)
+                ? new ClassMethodsHydrator()
+                : new ClassMethods()
+            )
+            ->setObject(new Entity\Country());
 
         $name = new \Zend\Form\Element('name', ['label' => 'Name of the country']);
         $name->setAttribute('type', 'text');

--- a/test/TestAsset/CreateAddressForm.php
+++ b/test/TestAsset/CreateAddressForm.php
@@ -1,16 +1,15 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form\TestAsset;
 
 use Zend\Form\Form;
-use Zend\Hydrator\ClassMethods as ClassMethodsHydrator;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ClassMethodsHydrator;
 
 class CreateAddressForm extends Form
 {
@@ -18,9 +17,14 @@ class CreateAddressForm extends Form
     {
         parent::__construct('create_address');
 
-        $this->setAttribute('method', 'post')
-             ->setHydrator(new ClassMethodsHydrator(false))
-             ->setInputFilter(new InputFilter());
+        $this
+            ->setAttribute('method', 'post')
+            ->setHydrator(
+                class_exists(ClassMethodsHydrator::class)
+                ? new ClassMethodsHydrator(false)
+                : new ClassMethods(false)
+            )
+            ->setInputFilter(new InputFilter());
 
         $address = new AddressFieldset();
         $address->setUseAsBaseFieldset(true);
@@ -29,8 +33,8 @@ class CreateAddressForm extends Form
         $this->add([
             'name' => 'submit',
             'attributes' => [
-                'type' => 'submit'
-            ]
+                'type' => 'submit',
+            ],
         ]);
     }
 }

--- a/test/TestAsset/CustomForm.php
+++ b/test/TestAsset/CustomForm.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form\TestAsset;
@@ -12,7 +10,8 @@ namespace ZendTest\Form\TestAsset;
 use Zend\Form\Form;
 use Zend\Form\Element;
 use Zend\Validator;
-use Zend\Hydrator\ClassMethods as ClassMethodsHydrator;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ClassMethodsHydrator;
 
 class CustomForm extends Form
 {
@@ -20,8 +19,13 @@ class CustomForm extends Form
     {
         parent::__construct('test_form');
 
-        $this->setAttribute('method', 'post')
-             ->setHydrator(new ClassMethodsHydrator());
+        $this
+            ->setAttribute('method', 'post')
+            ->setHydrator(
+                class_exists(ClassMethodsHydrator::class)
+                ? new ClassMethodsHydrator()
+                : new ClassMethods()
+            );
 
         $field1 = new Element('name', ['label' => 'Name']);
         $field1->setAttribute('type', 'text');

--- a/test/TestAsset/HydratorAwareModelHydratorV2.php
+++ b/test/TestAsset/HydratorAwareModelHydratorV2.php
@@ -1,11 +1,9 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
-*
-* @link      http://github.com/zendframework/zf2 for the canonical source repository
-* @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
-* @license   http://framework.zend.com/license/new-bsd New BSD License
-*/
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
+ */
 
 namespace ZendTest\Form\TestAsset;
 
@@ -13,7 +11,11 @@ use Zend\Hydrator\HydratorAwareInterface;
 use Zend\Hydrator\HydratorInterface;
 use Zend\Hydrator\ClassMethods;
 
-class HydratorAwareModel implements HydratorAwareInterface
+/**
+ * This test asset targest zend-hydrator v1 and v2, and will be aliased to
+ * HydratorAwareModel when of those versions is installed.
+ */
+class HydratorAwareModelHydratorV2 implements HydratorAwareInterface
 {
     protected $hydrator = null;
 

--- a/test/TestAsset/HydratorAwareModelHydratorV3.php
+++ b/test/TestAsset/HydratorAwareModelHydratorV3.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Hydrator\HydratorAwareInterface;
+use Zend\Hydrator\HydratorInterface;
+use Zend\Hydrator\ClassMethodsHydrator;
+
+/**
+ * This test asset targest zend-hydrator v3, and will be aliased to
+ * HydratorAwareModel when that version is installed.
+ */
+class HydratorAwareModelHydratorV3 implements HydratorAwareInterface
+{
+    protected $hydrator = null;
+
+    protected $foo = null;
+    protected $bar = null;
+
+    public function setHydrator(HydratorInterface $hydrator) : void
+    {
+        $this->hydrator = $hydrator;
+    }
+
+    public function getHydrator() : ?HydratorInterface
+    {
+        if (! $this->hydrator) {
+            $this->hydrator = new ClassMethodsHydrator();
+        }
+        return $this->hydrator;
+    }
+
+    public function setFoo($value)
+    {
+        $this->foo = $value;
+        return $this;
+    }
+
+    public function setBar($value)
+    {
+        $this->bar = $value;
+        return $this;
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+
+    public function getBar()
+    {
+        return $this->bar;
+    }
+}

--- a/test/TestAsset/HydratorStrategyHydratorV2.php
+++ b/test/TestAsset/HydratorStrategyHydratorV2.php
@@ -1,17 +1,19 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form\TestAsset;
 
 use Zend\Hydrator\Strategy\DefaultStrategy;
 
-class HydratorStrategy extends DefaultStrategy
+/**
+ * This class targets zend-hydrator v1 and v2, and will be aliased to
+ * HydratorStrategy when one of those versions is detected.
+ */
+class HydratorStrategyHydratorV2 extends DefaultStrategy
 {
     /**
      * A simulated storage device which is just an array with Car objects.
@@ -46,7 +48,7 @@ class HydratorStrategy extends DefaultStrategy
                 $result[] = $this->findEntity($field1);
             }
         }
-        return $result;
+        return (object) $result;
     }
 
     private function findEntity($field1)

--- a/test/TestAsset/HydratorStrategyHydratorV3.php
+++ b/test/TestAsset/HydratorStrategyHydratorV3.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+use Zend\Hydrator\Strategy\DefaultStrategy;
+
+/**
+ * This class targets zend-hydrator v3, and will be aliased to
+ * HydratorStrategy when that versions is detected.
+ */
+class HydratorStrategyHydratorV3 extends DefaultStrategy
+{
+    /**
+     * A simulated storage device which is just an array with Car objects.
+     *
+     * @var array
+     */
+    private $simulatedStorageDevice;
+
+    public function __construct()
+    {
+        $this->simulatedStorageDevice = [];
+        $this->simulatedStorageDevice[] = new HydratorStrategyEntityB(111, 'AAA');
+        $this->simulatedStorageDevice[] = new HydratorStrategyEntityB(222, 'BBB');
+        $this->simulatedStorageDevice[] = new HydratorStrategyEntityB(333, 'CCC');
+    }
+
+    public function extract($value, ?object $object = null) : array
+    {
+        $result = [];
+        foreach ($value as $instance) {
+            $result[] = $instance->getField1();
+        }
+        return $result;
+    }
+
+    public function hydrate($value, ?array $data = null) : object
+    {
+        $result = $value;
+        if (is_array($value)) {
+            $result = [];
+            foreach ($value as $field1) {
+                $result[] = $this->findEntity($field1);
+            }
+        }
+        return (object) $result;
+    }
+
+    private function findEntity($field1)
+    {
+        $result = null;
+        foreach ($this->simulatedStorageDevice as $entity) {
+            if ($entity->getField1() == $field1) {
+                $result = $entity;
+                break;
+            }
+        }
+        return $result;
+    }
+}

--- a/test/TestAsset/NewProductForm.php
+++ b/test/TestAsset/NewProductForm.php
@@ -1,16 +1,15 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form\TestAsset;
 
 use Zend\Form\Form;
-use Zend\Hydrator\ClassMethods as ClassMethodsHydrator;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ClassMethodsHydrator;
 
 class NewProductForm extends Form
 {
@@ -18,9 +17,14 @@ class NewProductForm extends Form
     {
         parent::__construct('create_product');
 
-        $this->setAttribute('method', 'post')
-             ->setHydrator(new ClassMethodsHydrator())
-             ->setInputFilter(new InputFilter());
+        $this
+            ->setAttribute('method', 'post')
+            ->setHydrator(
+                class_exists(ClassMethodsHydrator::class)
+                ? new ClassMethodsHydrator()
+                : new ClassMethods()
+            )
+            ->setInputFilter(new InputFilter());
 
         $fieldset = new ProductFieldset();
         $fieldset->setUseAsBaseFieldset(true);

--- a/test/TestAsset/OrphansFieldset.php
+++ b/test/TestAsset/OrphansFieldset.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form\TestAsset;
@@ -12,6 +10,7 @@ namespace ZendTest\Form\TestAsset;
 use Zend\Form\Fieldset;
 use Zend\InputFilter\InputFilterProviderInterface;
 use Zend\Hydrator\ArraySerializable;
+use Zend\Hydrator\ArraySerializableHydrator;
 use ZendTest\Form\TestAsset\Entity\Orphan;
 
 class OrphansFieldset extends Fieldset implements InputFilterProviderInterface
@@ -20,23 +19,28 @@ class OrphansFieldset extends Fieldset implements InputFilterProviderInterface
     {
         parent::__construct($name, $options);
 
-        $this->setHydrator(new ArraySerializable())
-                ->setObject(new Orphan());
+        $this
+            ->setHydrator(
+                class_exists(ArraySerializableHydrator::class)
+                ? new ArraySerializableHydrator()
+                : new ArraySerializable()
+            )
+            ->setObject(new Orphan());
 
         $this->add([
-                        'name' => 'name',
-                        'options' => ['label' => 'Name field'],
-                   ]);
+            'name'    => 'name',
+            'options' => ['label' => 'Name field'],
+        ]);
     }
 
     public function getInputFilterSpecification()
     {
         return [
             'name' => [
-                'required' => false,
-                'filters' => [],
+                'required'   => false,
+                'filters'    => [],
                 'validators' => [],
-            ]
+            ],
         ];
     }
 }

--- a/test/TestAsset/PhoneFieldset.php
+++ b/test/TestAsset/PhoneFieldset.php
@@ -1,17 +1,16 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form\TestAsset;
 
 use Zend\Form\Fieldset;
 use Zend\Form\Element;
-use Zend\Hydrator\ClassMethods as ClassMethodsHydrator;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ClassMethodsHydrator;
 use Zend\InputFilter\InputFilterProviderInterface;
 use ZendTest\Form\TestAsset\Entity\Phone;
 
@@ -21,7 +20,12 @@ class PhoneFieldset extends Fieldset implements InputFilterProviderInterface
     {
         parent::__construct('phones');
 
-        $this->setHydrator(new ClassMethodsHydrator)
+        $this
+            ->setHydrator(
+                class_exists(ClassMethodsHydrator::class)
+                ? new ClassMethodsHydrator()
+                : new ClassMethods()
+            )
              ->setObject(new Phone());
 
         $id = new Element\Hidden('id');

--- a/test/TestAsset/ProductFieldset.php
+++ b/test/TestAsset/ProductFieldset.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form\TestAsset;
@@ -12,15 +10,21 @@ namespace ZendTest\Form\TestAsset;
 use ZendTest\Form\TestAsset\Entity\Product;
 use Zend\Form\Fieldset;
 use Zend\InputFilter\InputFilterProviderInterface;
-use Zend\Hydrator\ClassMethods as ClassMethodsHydrator;
+use Zend\Hydrator\ClassMethods;
+use Zend\Hydrator\ClassMethodsHydrator;
 
 class ProductFieldset extends Fieldset implements InputFilterProviderInterface
 {
     public function __construct()
     {
         parent::__construct('product');
-        $this->setHydrator(new ClassMethodsHydrator())
-             ->setObject(new Product());
+        $this
+            ->setHydrator(
+                class_exists(ClassMethodsHydrator::class)
+                ? new ClassMethodsHydrator()
+                : new ClassMethods()
+            )
+            ->setObject(new Product());
 
         $this->add([
             'name' => 'name',
@@ -58,7 +62,9 @@ class ProductFieldset extends Fieldset implements InputFilterProviderInterface
             'type' => 'ZendTest\Form\TestAsset\CountryFieldset',
             'name' => 'made_in_country',
             'object' => 'ZendTest\Form\TestAsset\Entity\Country',
-            'hydrator' => 'Zend\Hydrator\ClassMethods',
+            'hydrator' => class_exists(ClassMethodsHydrator::class)
+                ? ClassMethodsHydrator::class
+                : ClassMethods::class,
             'options' => [
                 'label' => 'Please choose the country',
             ]

--- a/test/_autoload.php
+++ b/test/_autoload.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-hydrator for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-hydrator/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Form;
+
+use Zend\Hydrator\HydratorPluginManagerInterface;
+
+// @codingStandardsIgnoreStart
+if (interface_exists(HydratorPluginManagerInterface::class)) {
+    class_alias(TestAsset\Annotation\ComplexEntityHydratorV3::class, TestAsset\Annotation\ComplexEntity::class, true);
+    class_alias(TestAsset\Annotation\EntityUsingInstancePropertyHydratorV3::class, TestAsset\Annotation\EntityUsingInstanceProperty::class, true);
+    class_alias(TestAsset\Annotation\EntityUsingObjectPropertyHydratorV3::class, TestAsset\Annotation\EntityUsingObjectProperty::class, true);
+    class_alias(TestAsset\Annotation\EntityWithHydratorArrayHydratorV3::class, TestAsset\Annotation\EntityWithHydratorArray::class, true);
+    class_alias(TestAsset\HydratorAwareModelHydratorV3::class, TestAsset\HydratorAwareModel::class, true);
+    class_alias(TestAsset\HydratorStrategyHydratorV3::class, TestAsset\HydratorStrategy::class, true);
+} else {
+    class_alias(TestAsset\Annotation\ComplexEntityHydratorV2::class, TestAsset\Annotation\ComplexEntity::class, true);
+    class_alias(TestAsset\Annotation\EntityUsingInstancePropertyHydratorV2::class, TestAsset\Annotation\EntityUsingInstanceProperty::class, true);
+    class_alias(TestAsset\Annotation\EntityUsingObjectPropertyHydratorV2::class, TestAsset\Annotation\EntityUsingObjectProperty::class, true);
+    class_alias(TestAsset\Annotation\EntityWithHydratorArrayHydratorV2::class, TestAsset\Annotation\EntityWithHydratorArray::class, true);
+    class_alias(TestAsset\HydratorAwareModelHydratorV2::class, TestAsset\HydratorAwareModel::class, true);
+    class_alias(TestAsset\HydratorStrategyHydratorV2::class, TestAsset\HydratorStrategy::class, true);
+}
+// @codingStandardsIgnoreEnd


### PR DESCRIPTION
This patch provides compatibility with zend-hydrator v3, while retaining compatibility with versions 1 and 2.

The primary change that affects this package is that the default shipped hydrators were given the suffix `Hydrator`. The original still exist, but emit deprecation notices when used.

The `Fieldset` class is the only one in the source library that references a specific hydrator. That reference was changed to check if the v3 variant exists, using that when found and the v1/v2 variant otherwise.  Additionally, due to the stricter typehints in zend-hydrator v3, a check was necessary within `bindValues()` for a populated `$object` property prior to attemting hydration.

The bulk of the effort was getting the tests to pass with both versions, as the deprecation notices can prevent test passage when v3 is installed. All tests were updated to vary hydrator usage based on zend-hydrator version installed. In a number of cases, test assets were duplicated when varying was impossible to perform programmatically; for these cases, I provided autoload-dev rules that perform class aliases.