### PR TITLE
Fixed the "__clone method called on non-object" error that happens when the targetElement is null.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#230](https://github.com/zendframework/zend-form/pull/230) fixes the "__clone method called on non-object" error that happens when the targetElement is null.
 
 ## 2.14.0 - 2019-01-07
 

--- a/src/Element/Collection.php
+++ b/src/Element/Collection.php
@@ -225,6 +225,7 @@ class Collection extends Fieldset
         }
 
         foreach ($data as $key => $value) {
+            $elementOrFieldset = null;
             if ($this->has($key)) {
                 $elementOrFieldset = $this->get($key);
             } elseif ($this->targetElement) {

--- a/src/Element/Collection.php
+++ b/src/Element/Collection.php
@@ -236,7 +236,7 @@ class Collection extends Fieldset
                 }
             }
 
-            if ($elementOrFieldset) {
+            if ($elementOrFieldset !== null) {
                 if ($elementOrFieldset instanceof FieldsetInterface) {
                     $elementOrFieldset->populateValues($value);
                 } else {

--- a/src/Element/Collection.php
+++ b/src/Element/Collection.php
@@ -227,7 +227,7 @@ class Collection extends Fieldset
         foreach ($data as $key => $value) {
             if ($this->has($key)) {
                 $elementOrFieldset = $this->get($key);
-            } else {
+            } elseif ($this->targetElement) {
                 $elementOrFieldset = $this->addNewTargetElementInstance($key);
 
                 if ($key > $this->lastChildIndex) {
@@ -235,10 +235,12 @@ class Collection extends Fieldset
                 }
             }
 
-            if ($elementOrFieldset instanceof FieldsetInterface) {
-                $elementOrFieldset->populateValues($value);
-            } else {
-                $elementOrFieldset->setAttribute('value', $value);
+            if ($elementOrFieldset) {
+                if ($elementOrFieldset instanceof FieldsetInterface) {
+                    $elementOrFieldset->populateValues($value);
+                } else {
+                    $elementOrFieldset->setAttribute('value', $value);
+                }
             }
         }
 

--- a/test/Element/CollectionTest.php
+++ b/test/Element/CollectionTest.php
@@ -1403,20 +1403,34 @@ class CollectionTest extends TestCase
     {
         $form = new Form();
 
-        $form->add([
-            'type' => 'Zend\Form\Element\Collection',
-            'name' => 'fieldsets',
-            'options' => [
-                'count' => 2
+        $form->add(
+            [
+                'type' => \Zend\Form\Element\Collection::class,
+                'name' => 'fieldsets',
+                'options' => [
+                    'count' => 2
+                ]
             ]
-        ]);
+        );
 
         $collection = $form->get('fieldsets');
-        $data = [];
-        $data['fieldsets'] = ['red', 'green', 'blue'];
+        $data = [
+            'fieldsets' => [
+                'red',
+                'green',
+                'blue'
+            ]
+        ];
 
-        $form->populateValues($data);
+        $form->setData($data);
+        $form->isValid();
 
-        $this->addToAssertionCount(1); // expect no exception being thrown
+        // expect the fieldsets key to be an empty array since there's no valid targetElement
+        $this->assertEquals(
+            [
+                'fieldsets' => []
+            ],
+            $form->getData()
+        );
     }
 }

--- a/test/Element/CollectionTest.php
+++ b/test/Element/CollectionTest.php
@@ -1398,4 +1398,25 @@ class CollectionTest extends TestCase
             $this->form->getMessages()
         );
     }
+
+    public function testTargetElementBeingNullNotCausingAnError()
+    {
+        $form = new Form();
+
+        $form->add([
+            'type' => 'Zend\Form\Element\Collection',
+            'name' => 'fieldsets',
+            'options' => [
+                'count' => 2
+            ]
+        ]);
+
+        $collection = $form->get('fieldsets');
+        $data = [];
+        $data['fieldsets'] = ['red', 'green', 'blue'];
+
+        $form->populateValues($data);
+
+        $this->addToAssertionCount(1); // expect no exception being thrown
+    }
 }


### PR DESCRIPTION
I was getting the `__clone method called on non-object` error while populating data in the fieldset and there was no targetElement available (it was null).

I think such a fix should not create regressions in the software since when targetElement is null it errors anyway.

I'll provide the changelog entry and regression text in later commits (since it seems like I need an issue number for the fix which I'm going to get after submitting this pull request).