### PR TITLE
Fix validation of $creationOptions in ElementFactory

### DIFF
--- a/src/ElementFactory.php
+++ b/src/ElementFactory.php
@@ -37,6 +37,17 @@ final class ElementFactory implements FactoryInterface
         if (null === $creationOptions) {
             return;
         }
+        if ($creationOptions instanceof Traversable) {
+            $creationOptions = iterator_to_array($creationOptions);
+        }
+
+        if (! is_array($creationOptions)) {
+            throw new InvalidServiceException(sprintf(
+                '%s cannot use non-array, non-traversable, non-null creation options; received %s',
+                __CLASS__,
+                (is_object($creationOptions) ? get_class($creationOptions) : gettype($creationOptions))
+            ));
+        }
 
         $this->setCreationOptions($creationOptions);
     }
@@ -118,18 +129,6 @@ final class ElementFactory implements FactoryInterface
      */
     public function setCreationOptions(array $creationOptions)
     {
-        if ($creationOptions instanceof Traversable) {
-            $creationOptions = iterator_to_array($creationOptions);
-        }
-
-        if (! is_array($creationOptions)) {
-            throw new InvalidServiceException(sprintf(
-                '%s cannot use non-array, non-traversable creation options; received %s',
-                __CLASS__,
-                (is_object($creationOptions) ? get_class($creationOptions) : gettype($creationOptions))
-            ));
-        }
-
         $this->creationOptions = $creationOptions;
     }
 }

--- a/src/ElementFactory.php
+++ b/src/ElementFactory.php
@@ -37,6 +37,7 @@ final class ElementFactory implements FactoryInterface
         if (null === $creationOptions) {
             return;
         }
+
         if ($creationOptions instanceof Traversable) {
             $creationOptions = iterator_to_array($creationOptions);
         }
@@ -45,7 +46,7 @@ final class ElementFactory implements FactoryInterface
             throw new InvalidServiceException(sprintf(
                 '%s cannot use non-array, non-traversable, non-null creation options; received %s',
                 __CLASS__,
-                (is_object($creationOptions) ? get_class($creationOptions) : gettype($creationOptions))
+                is_object($creationOptions) ? get_class($creationOptions) : gettype($creationOptions)
             ));
         }
 

--- a/test/ElementFactoryTest.php
+++ b/test/ElementFactoryTest.php
@@ -1,40 +1,64 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form;
 
 use ArrayObject;
+use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
 use Zend\Form\ElementFactory;
+use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZendTest\Form\TestAsset\ArgumentRecorder;
 
-/**
- * @group      Zend_Form
- */
-class FormElementManagerTest extends TestCase
+class ElementFactoryTest extends TestCase
 {
-    public function testCreationOptionsHandled()
+    public function validCreationOptions()
     {
-        $this->assertCreationOptionsOfServiceAreSet(['key' => 'value'], new ArrayObject(['key' => 'value']));
-        $this->assertCreationOptionsOfServiceAreSet(['key' => 'value'], ['key' => 'value']);
-        $this->assertCreationOptionsOfServiceAreSet([], []);
-        $this->assertCreationOptionsOfServiceAreSet([], null);
+        yield 'ArrayObject' => [new ArrayObject(['key' => 'value']), ['key' => 'value']];
+        yield 'array' => [['key' => 'value'], ['key' => 'value']];
+        yield 'empty-array' => [[], []];
+        yield 'null' => [null, []];
     }
 
-    private function assertCreationOptionsOfServiceAreSet($expectedValue, $input)
+    /**
+     * @dataProvider validCreationOptions
+     *
+     * @param mixed $creationOptions
+     * @param array $expectedValue
+     */
+    public function testValidCreationOptions($creationOptions, array $expectedValue)
     {
-        $serviceLocator = $this->prophesize(ServiceLocatorInterface::class)->reveal();
+        $container = $this->prophesize(ServiceLocatorInterface::class)
+            ->willImplement(ContainerInterface::class)
+            ->reveal();
 
-        $factory = new ElementFactory($input);
-        $result = $factory->createService($serviceLocator, ArgumentRecorder::class);
+        $factory = new ElementFactory($creationOptions);
+        $result = $factory->createService($container, ArgumentRecorder::class);
         $this->assertInstanceOf(ArgumentRecorder::class, $result);
         $this->assertSame(['argumentrecorder', $expectedValue], $result->args);
+    }
+
+    public function invalidCreationOptions()
+    {
+        yield 'object' => [(object) ['key' => 'val']];
+        yield 'int' => [PHP_INT_MAX];
+        yield 'string' => [uniqid('', true)];
+    }
+
+    /**
+     * @dataProvider invalidCreationOptions
+     *
+     * @param $creationOptions
+     */
+    public function testInvalidCreationOptionsException($creationOptions)
+    {
+        $this->expectException(InvalidServiceException::class);
+        $this->expectExceptionMessage('cannot use non-array, non-traversable, non-null creation options;');
+        new ElementFactory($creationOptions);
     }
 }

--- a/test/ElementFactoryTest.php
+++ b/test/ElementFactoryTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form;
+
+use ArrayObject;
+use PHPUnit\Framework\TestCase;
+use Zend\Form\ElementFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZendTest\Form\TestAsset\ArgumentRecorder;
+
+/**
+ * @group      Zend_Form
+ */
+class FormElementManagerTest extends TestCase
+{
+    public function testCreationOptionsHandled()
+    {
+        $this->assertCreationOptionsOfServiceAreSet(['key' => 'value'], new ArrayObject(['key' => 'value']));
+        $this->assertCreationOptionsOfServiceAreSet(['key' => 'value'], ['key' => 'value']);
+        $this->assertCreationOptionsOfServiceAreSet([], []);
+        $this->assertCreationOptionsOfServiceAreSet([], null);
+    }
+
+    private function assertCreationOptionsOfServiceAreSet($expectedValue, $input)
+    {
+        $serviceLocator = $this->prophesize(ServiceLocatorInterface::class)->reveal();
+
+        $factory = new ElementFactory($input);
+        $result = $factory->createService($serviceLocator, ArgumentRecorder::class);
+        $this->assertInstanceOf(ArgumentRecorder::class, $result);
+        $this->assertSame(['argumentrecorder', $expectedValue], $result->args);
+    }
+}

--- a/test/TestAsset/ArgumentRecorder.php
+++ b/test/TestAsset/ArgumentRecorder.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Form\TestAsset;
+
+class ArgumentRecorder {
+    public $args;
+    public function __construct(...$args) {
+        $this->args = $args;
+    }
+}

--- a/test/TestAsset/ArgumentRecorder.php
+++ b/test/TestAsset/ArgumentRecorder.php
@@ -1,17 +1,18 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2019 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-form for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-form/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Form\TestAsset;
 
-class ArgumentRecorder {
+class ArgumentRecorder
+{
     public $args;
-    public function __construct(...$args) {
+
+    public function __construct(...$args)
+    {
         $this->args = $args;
     }
 }


### PR DESCRIPTION
In setCreationOptions(array $options), a TypeError would be thrown if it
was anything other than an array.

Move the exceptions and traversable checks to the constructor.

(This impossible condition was detected by Phan)

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently. Calling __construct with Traversable
  - [x] Detail the original, incorrect behavior. `__construct would throw a TypeError if passed a Traversable, contrary to documentation
  - [x] Detail the new, expected behavior. `__construct` will convert traversables to arrays.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
