### PR TITLE
fix Trying to access array offset on value of type null (7.4)

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -364,7 +364,12 @@ class Form extends Fieldset implements FormInterface
             $data = array_key_exists($this->baseFieldset->getName(), $data)
                 ? $data[$this->baseFieldset->getName()]
                 : [];
-            $this->object = $this->baseFieldset->bindValues($data, $validationGroup ? $validationGroup[$this->baseFieldset->getName()] : null);
+            $this->object = $this->baseFieldset->bindValues(
+                $data,
+                isset($validationGroup[$this->baseFieldset->getName()])
+                    ? $validationGroup[$this->baseFieldset->getName()]
+                    : []
+            );
         } else {
             $this->object = parent::bindValues($data, $validationGroup);
         }

--- a/src/Form.php
+++ b/src/Form.php
@@ -364,7 +364,7 @@ class Form extends Fieldset implements FormInterface
             $data = array_key_exists($this->baseFieldset->getName(), $data)
                 ? $data[$this->baseFieldset->getName()]
                 : [];
-            $this->object = $this->baseFieldset->bindValues($data, $validationGroup[$this->baseFieldset->getName()]);
+            $this->object = $this->baseFieldset->bindValues($data, $validationGroup ? $validationGroup[$this->baseFieldset->getName()] : null);
         } else {
             $this->object = parent::bindValues($data, $validationGroup);
         }


### PR DESCRIPTION
```
There were 8 errors:

1) ZendTest\Form\Element\CollectionTest::testDoesNotCreateNewObjects
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:367
/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:519
/dev/shm/BUILD/zend-form-284f51cf26af2d3d88936fd8b74d46853550b718*/test/Element/CollectionTest.php:442

2) ZendTest\Form\Element\CollectionTest::testCreatesNewObjectsIfSpecified
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:367
/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:519
/dev/shm/BUILD/zend-form-284f51cf26af2d3d88936fd8b74d46853550b718*/test/Element/CollectionTest.php:494

3) ZendTest\Form\FormTest::testFormBaseFieldsetBindValuesWithoutInputs
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:367
/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:519
/dev/shm/BUILD/zend-form-284f51cf26af2d3d88936fd8b74d46853550b718*/test/FormTest.php:866

4) ZendTest\Form\FormTest::testCanCorrectlyPopulateDataToComposedEntities
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:367
/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:519
/dev/shm/BUILD/zend-form-284f51cf26af2d3d88936fd8b74d46853550b718*/test/FormTest.php:1153

5) ZendTest\Form\FormTest::testCanCorrectlyPopulateDataToOneToManyEntites
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:367
/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:519
/dev/shm/BUILD/zend-form-284f51cf26af2d3d88936fd8b74d46853550b718*/test/FormTest.php:1202

6) ZendTest\Form\FormTest::testCorrectlyHydrateBaseFieldsetWhenHydratorThatDoesNotIgnoreInvalidDataIsUsed
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:367
/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:519
/dev/shm/BUILD/zend-form-284f51cf26af2d3d88936fd8b74d46853550b718*/test/FormTest.php:1612

7) ZendTest\Form\FormTest::testPreserveEntitiesBoundToCollectionAfterValidation
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:367
/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:519
/dev/shm/BUILD/zend-form-284f51cf26af2d3d88936fd8b74d46853550b718*/test/FormTest.php:1694

8) ZendTest\Form\FormTest::testShouldHydrateEmptyCollection
Trying to access array offset on value of type null

/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:367
/dev/shm/BUILDROOT/php-zendframework-zend-form-2.14.2-1.fc29.remi.x86_64/usr/share/php/Zend/Form/Form.php:519
/dev/shm/BUILD/zend-form-284f51cf26af2d3d88936fd8b74d46853550b718*/test/FormTest.php:2349

```